### PR TITLE
Modified update and install scripts to address 406 errors

### DIFF
--- a/automatic/Executor/tools/ChocolateyInstall.ps1
+++ b/automatic/Executor/tools/ChocolateyInstall.ps1
@@ -1,20 +1,11 @@
 ﻿$ErrorActionPreference = 'Stop'
-$url32          = ''
-$checksum32     = ''
-$checksumType32 = ''
 
 $packageArgs = @{
-    url             = $url32
-    fileType        = 'exe'
-    softwareName    = $env:ChocolateyPackageName
-    packageName     = $env:ChocolateyPackageName
-    silentArgs      = '/verysilent'
-    checksum        = $checksum32
-    checksumType    = $checksumType32
-    Options = @{
-        Headers = @{
-            referer = "http://www.1space.dk/executor/download.html"
-        }
-    }
+    PackageName     = $env:ChocolateyPackageName
+    FileType        = 'exe'
+    Url             = 'http://www.1space.dk/executor/ExecutorSetup.exe'
+    Checksum        = '10D170EEBE36D0E43F2A2BDE0F7E3712BB82AC8141D60126BDEBF67A3F191B79'
+    ChecksumType    = 'sha256'
+    SilentArgs      = '/SILENT /VERYSILENT /SUPRESSMSGBOXES /SP-'
 }
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Http 406 errors were blocking the execution of the update script.  The
error was being returned on the au validation of the Url.  To address
this the flags were updated to skip the Url check.

In addition to addressing the base Http 406 error some reformatting
and simplification updates were made.

This addresses the issue flagged in chocolatey-community/chocolatey-package-requests/issues/880

Proposed changes in this pull request:
- Update au invocation to suppress URL check
- Populate chocolateyInstall.ps1 with correct values for the 0.99.32-b version
- Simplify scripting
- Minor formatting changes

- [X] PR as been tested
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/2788)
<!-- Reviewable:end -->
