### PR TITLE
(JCP) Remove unnecessary variable

### DIFF
--- a/automatic/jcpicker/tools/chocolateyInstall.ps1
+++ b/automatic/jcpicker/tools/chocolateyInstall.ps1
@@ -8,7 +8,6 @@ $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 Install-ChocolateyZipPackage -PackageName "$packageName" `
                              -Url "$url" `
                              -UnzipLocation "$toolsDir" `
-                             -Url64bit "" `
                              -Checksum "$checksum" `
                              -ChecksumType "$checksumType"
 


### PR DESCRIPTION
The 64 bit URL variable isn't being used, so can be removed.

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/2830)
<!-- Reviewable:end -->
