### PR TITLE
Fix version check

### DIFF
--- a/automatic/sdio/tools/chocolateyinstall.ps1
+++ b/automatic/sdio/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $os=(Get-WMIObject win32_operatingsystem).Version.split('.')
-if(($os[0] -le 6) -and ($os[1] -le 3)) {
+if(([Int]$os[0] -le 6) -and ([Int]$os[1] -le 3)) {
     Write-output "Operating system not supported"
     exit 0;
 }


### PR DESCRIPTION
Previously incorrectly compared string `"10"` with int `6`, which is `True` in PowerShell... so the package install aborted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/2912)
<!-- Reviewable:end -->
