### PR TITLE
Also update $fullVersion

### DIFF
--- a/automatic/sdio/update.ps1
+++ b/automatic/sdio/update.ps1
@@ -9,6 +9,7 @@ function global:au_SearchReplace {
             "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*.fileName32\s*=\s*)('.*')"  = "`$1'SDIO_R$($Latest.baseVersion).exe'"
             "(?i)(^\s*.fileName64\s*=\s*)('.*')"  = "`$1'SDIO_x64_R$($Latest.baseVersion).exe'"
+            "(?i)(^\s*.fullVersion\s*=\s*)('.*')" = "`$1'$($Latest.version)'"
         }
 
         ".\legal\VERIFICATION.txt" = @{


### PR DESCRIPTION
Fixes that the $fullVersion variable was not being updated. It is needed to produce a correct path name.

Proposed changes in this pull request:
- set it to `'Latest.version'`, which seems to be correct

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/2913)
<!-- Reviewable:end -->
