### PR TITLE
Correct 64 bit install path

### DIFF
--- a/automatic/gramps/tools/chocolateyInstall.ps1
+++ b/automatic/gramps/tools/chocolateyInstall.ps1
@@ -5,8 +5,8 @@ $silentArgs         = '/S'
 $url                = 'https://github.com/gramps-project/gramps/releases/download/v5.1.3/GrampsAIO-5.1.3-1_win32.exe'
 $checksum           = 'da88cb39bf75ebcbbf22c9e276e682620ddb4885ca7c04f1d3922d818095c0e3'
 $checksumType       = 'sha256'
-$url64              = 'https://github.com/gramps-project/gramps/releases/download/v5.1.3/GrampsAIO-5.1.3-2_win32.exe'
-$checksum64         = 'bbe69ebcf2f35f456243081593dcc87a7175967302638bd475a3a87ab4feb785'
+$url64              = 'https://github.com/gramps-project/gramps/releases/download/v5.1.3/GrampsAIO-5.1.3-2_win64.exe'
+$checksum64         = '0962b59f62195c8d65f2c586903dd90d578840c5edbffe98defe23951186432b'
 $checksumType64     = 'sha256'
 $validExitCodes     = @(0)
 


### PR DESCRIPTION
Currently the installer is installing the 32 bit version of Gramps on a 64 bit system. 

This is due to an incorrect URL in the chocolateyinstall.ps1 script, which points to a 32 bit installer.

Proposed changes in this pull request:
- Correct URL to 64 bit installer
- Update SHA256 checksum for 64-bit installer


- [x] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/2959)
<!-- Reviewable:end -->
