### PR TITLE
Fix wrong installer download URL for winmerge

### DIFF
--- a/automatic/winmerge/tools/chocolateyInstall.ps1
+++ b/automatic/winmerge/tools/chocolateyInstall.ps1
@@ -1,11 +1,11 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $packageName    = 'WinMerge'
-$url32          = 'https://github.com/WinMerge/winmerge/releases/download/v2.16.13/WinMerge-2.16.13-ARM64-Setup.exe'
-$checksum32     = '3339193738d5bec722900d5838caf27909b70390be9d29c98f2ecdc6d66f8cfb'
+$url32          = 'https://github.com/WinMerge/winmerge/releases/download/v2.16.13/WinMerge-2.16.13-Setup.exe'
+$checksum32     = '81253911d433b5fb85df8ba1e97c7a9b11bc65112b8682b39250d9d3ff2a2763'
 $checksumType32 = 'sha256'
-$url64          = 'https://github.com/WinMerge/winmerge/releases/download/v2.16.13/WinMerge-2.16.13-Setup.exe'
-$checksum64     = '81253911d433b5fb85df8ba1e97c7a9b11bc65112b8682b39250d9d3ff2a2763'
+$url64          = 'https://github.com/WinMerge/winmerge/releases/download/v2.16.13/WinMerge-2.16.13-x64-Setup.exe'
+$checksum64     = '9e34a32b47bdbb43a764377ffaa3c9d594df8a46f679795ca19a872d547b2eb3'
 $checksumType64 = 'sha256'
 
 $packageArgs = @{

--- a/automatic/winmerge/update.ps1
+++ b/automatic/winmerge/update.ps1
@@ -17,7 +17,7 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $installer = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_.href -match ".exe$"} | Where-Object {$_.href -notmatch "PerUser"} | Select-Object -First 2 | Sort-Object ).href
+    $installer = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_.href -match ".exe$"} | Where-Object {$_.href -notmatch "PerUser"} | Where-Object {$_.href -notmatch "ARM64"} | Select-Object -First 2 | Sort-Object ).href
     $url32 = "https://github.com$($installer[1])";
 	$url64 = "https://github.com$($installer[0])";
 


### PR DESCRIPTION
This WinMerge Chocolatey package downloads the installers from the wrong download URL since WinMerge 2.16.12.

The download URL of the 64-bit version installer is the 32-bit version installer, and the download URL of the 32-bit version installer is the ARM64 version installer.

Probably due to the addition of the ARM64 version of the installer from WinMerge 2.16.12.

This PR fixes the above wrong download URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/3000)
<!-- Reviewable:end -->
