### PR TITLE
Fixes WinMerge Setup Match

### DIFF
--- a/automatic/winmerge/update.ps1
+++ b/automatic/winmerge/update.ps1
@@ -17,9 +17,9 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $installer = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_.href -match ".exe$"} | Where-Object {$_.href -notmatch "PerUser"} | Select-Object -First 2 | Sort-Object ).href
-    $url32 = "https://github.com$($installer[1])";
-	$url64 = "https://github.com$($installer[0])";
+    $installers = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_.href -match ".exe$"} | Where-Object {$_.href -notmatch "PerUser"}).href
+    $url32 = "https://github.com$($installers.Where({$_ -match "(?<!64)-Setup\.exe$"}, 1))";
+    $url64 = "https://github.com$($installers.Where({$_ -like "*-X64-Setup.exe"}, 1))";
 
     $version = ($installer | Where-Object {$_ -notmatch 'ARM'}).split('-') | select-object -Last 1 -Skip 1
     $tags = Invoke-WebRequest 'https://api.github.com/repos/WinMerge/winmerge/releases' -UseBasicParsing | ConvertFrom-Json


### PR DESCRIPTION
WinMerge releases has either changed order or added additional. This messes with the matching used by the AU GetLatest script.

This commit should fix that, by selecting the first result matching either `-x64-Setup.exe` or `(not 64)-Setup.exe`.

Fixes #3009 
Fixes #3004
Fixes #3008

(assuming this needs to be fixed before new versions get approved)

Proposed changes in this pull request:
- Updates WinMerge's AU GetLatest script to handle less predictable ordering on the releases page

- [x] PR has been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/3012)
<!-- Reviewable:end -->
