### PR TITLE
Fix boinc update URL, roll back to stable 7.16.11

### DIFF
--- a/automatic/boinc/boinc.nuspec
+++ b/automatic/boinc/boinc.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one.-->
-<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>boinc</id>
-    <version>7.16.16</version>
+    <version>7.16.16.20210820</version>
     <title>BOINC</title>
     <authors>University of California</authors>
     <owners>tunisiano</owners>
@@ -27,7 +27,7 @@ After installing, run `BoincMgr.exe` and choose a [BOINC project](https://boinc.
 ### Package-specific issue
 If this package isn't up-to-date for some days, [Create an issue](https://github.com/tunisiano187/Chocolatey-packages/issues/new/choose)
 
-[![Patreon](https://cdn.jsdelivr.net/gh/tunisiano187/Chocolatey-packages@d15c4e19c709e7148588d4523ffc6dd3cd3c7e5e/icons/patreon.png)](https://www.patreon.com/tunisiano)
+Support the package maintainer and [![Patreon](https://cdn.jsdelivr.net/gh/tunisiano187/Chocolatey-packages@d15c4e19c709e7148588d4523ffc6dd3cd3c7e5e/icons/patreon.png)](https://www.patreon.com/tunisiano)
 ]]></description>
     <summary>Berkeley Open Infrastructure for Network Computing</summary>
     <releaseNotes>#### Program

--- a/automatic/boinc/tools/chocolateyInstall.ps1
+++ b/automatic/boinc/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 $packageName = $env:ChocolateyPackageName
 $installerType = 'exe'
 $silentArgs = '/S /v/qn'
-$url = 'https://boinc.berkeley.edu/dl/boinc_7.16.16_windows_x86_64.exe'
-$checksum = '4542e15073b7bd27c08ab0e9d8238c83e49980c94e4b34ebde07d6b5d7246bec'
+$url = 'https://boinc.berkeley.edu/dl/boinc_7.16.11_windows_x86_64.exe'
+$checksum = '28b1aa0f7edbd78402b7163bc483a909b156064860b8890e52667a597079fb33'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
 

--- a/automatic/boinc/update.ps1
+++ b/automatic/boinc/update.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 import-module au
 
-$releases = 'https://boinc.berkeley.edu/dl/'
+$releases = 'https://boinc.berkeley.edu/download.php'
 
 function global:au_SearchReplace {
 	@{
@@ -13,13 +13,10 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-	$installer = (((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_ -match 'windows'} | Where-Object {$_ -match 'windows_x86_64.exe'} | Where-Object {$_ -match 'boinc_'}).href)[-1]
+	$installer = (((Invoke-WebRequest -Uri $releases -UserAgent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36" -UseBasicParsing).Links | Where-Object {$_ -match 'windows_x86_64.exe'} | Where-Object {$_ -match 'boinc_'}).Href)
 	$version = Get-Version $installer
-	if($version -match '7.16.16') {
-		$version = '7.16.16.20201101'
-	}
 	Write-Output "Version : $version"
-	$url32 = "$($releases)$($installer)"
+	$url32 = "$($installer)"
 
 	$Latest = @{ URL32 = $url32; Version = $version }
 	return $Latest


### PR DESCRIPTION
Fixes #3006

Proposed changes in this pull request:
- Corrects BOINC releases URL, specifies 64 bit user agent string to force correct version from `boinc.berkeley.edu/download.php`
- Returns BOINC package version to stable 7.16.11

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/3013)
<!-- Reviewable:end -->
