### PR TITLE
Update audacious to 4.1

### DIFF
--- a/automatic/audacious/tools/chocolateyInstall.ps1
+++ b/automatic/audacious/tools/chocolateyInstall.ps1
@@ -18,3 +18,4 @@ $packageArgs = @{
 }
 
 Install-ChocolateyPackage @packageArgs
+

--- a/automatic/audacious/tools/chocolateyInstall.ps1
+++ b/automatic/audacious/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName = $env:ChocolateyPackageName
-$url = 'https://distfiles.audacious-media-player.org/audacious-4.1-beta1-win32.exe'
-$checksum = 'f853c7c04197b854a87ff63778faba9d942d9998f85689c61f8281a11a0f03c1'
+$url = 'https://distfiles.audacious-media-player.org/audacious-4.1-win32.exe'
+$checksum = '5357cda5e9f225f4cc63eddd0e744b7179d59bc48f3a395b175835936d69a250'
 $checksumType = 'sha256'
 $silentArgs = '/S'
 $validExitCodes = @(0)


### PR DESCRIPTION
This PR updates the used audacious version to latest stable 4.1.
The version one defined in the install script/metadata is still referring to 4.1-beta.
The script was running successfully on my local machine.

EDIT: Unfortunately, the automated build fails because of failing updates

Proposed changes in this pull request:
- update audacious to stable 4.1


- [X] PR as been tested
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/3020)
<!-- Reviewable:end -->
