### PR TITLE
Correct latest nano-win version from release page

### DIFF
--- a/automatic/nano-win/update.ps1
+++ b/automatic/nano-win/update.ps1
@@ -15,10 +15,10 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
 	Write-Verbose 'Get files'
-	$filename = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_ -match '.7z'} | Select-Object -Last 1).href
+	$filename = (Invoke-WebRequest -Uri $releases -UseBasicParsing).Links.href | Where-Object {$_ -match '\.7z'} | Sort-Object | Select-Object -Last 1
 	Write-Verbose 'Checking version'
-	$version = $($filename).split('v|g')[-2].replace('-','.')
-	$version = $version.Substring(0,$version.Length-1)
+	$fileversion_regex = '(?<=v)[0-9\.\-]+[0-9](?!=\[0-9])'
+	$version = ($filename | Select-String -Pattern $fileversion_regex).Matches.Value -replace '-','.'
 
 	$url32 = $releases + $filename
 	Write-Verbose "Version : $version"

--- a/automatic/nano/update.ps1
+++ b/automatic/nano/update.ps1
@@ -13,10 +13,10 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
 	Write-Verbose 'Get files'
-	$filename = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_ -match '.7z'} | Select-Object -Last 1).href
+	$filename = (Invoke-WebRequest -Uri $releases -UseBasicParsing).Links.href | Where-Object {$_ -match '\.7z'} | Sort-Object | Select-Object -Last 1
 	Write-Verbose 'Checking version'
-	$version=$($filename).split('v|g')[-2].replace('-','.')
-	$version=$version.Substring(0,$version.Length-1)
+	$fileversion_regex = '(?<=v)[0-9\.\-]+[0-9](?!=\[0-9])'
+	$version = ($filename | Select-String -Pattern $fileversion_regex).Matches.Value -replace '-','.'
 
 	$url32 = $releases + $filename
 	Write-Verbose "Version : $version"


### PR DESCRIPTION
Affects nano and nano-win updates.

Proposed changes in this pull request:
- Select the correct latest ".7z" file by sorting links on the release page
- Use regular expression to extract version from file name


- [ ] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tunisiano187/chocolatey-packages/3079)
<!-- Reviewable:end -->
