### PR TITLE
Bonjour - Fix package, update script optimizations, install improvements

### DIFF
--- a/automatic/bonjour/tools/chocolateyinstall.ps1
+++ b/automatic/bonjour/tools/chocolateyinstall.ps1
@@ -28,6 +28,9 @@ $packageArgs = @{
 Get-ChocolateyWebFile @packageArgs
 Get-ChocolateyUnzip -fileFullPath $fileFullPath -destination $toolsDir
 
+$ignoreFilePath = Join-Path -Path $toolsDir -ChildPath "SetupAdmin.exe.ignore"
+Set-Content -Path $ignoreFilePath -Value $null -ErrorAction SilentlyContinue
+
 $bonjour = (Get-ChildItem -Path $toolsDir -Filter "Bonjour*.msi").FullName
 
 $packageArgs = @{

--- a/automatic/bonjour/tools/chocolateyinstall.ps1
+++ b/automatic/bonjour/tools/chocolateyinstall.ps1
@@ -42,4 +42,4 @@ $packageArgs = @{
   silentArgs	= "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
 }
 
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -21,7 +21,7 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate($Package) {
 	$Latest.ChecksumType32 = $Latest.ChecksumType64 = "SHA256"
 	$Latest.Checksum32 = (Get-FileHash -Path $exeFile -Algorithm $Latest.ChecksumType32).Hash.ToLower()
-	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType32 -Url $Latest.URL64
+	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType64 -Url $Latest.URL64
 }
 
 function global:au_AfterUpdate($Package) {

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -27,8 +27,8 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$url32 = "$($releases)32"
-	$url64 = "$($releases)64"
+	$url32 = Get-RedirectedUrl -url "$($releases)32"
+	$url64 = Get-RedirectedUrl -url "$($releases)64"
 	$startdir = Get-Location
 	$install_fname = 'bonjour.exe'
 	Write-Output 'Download'

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -2,6 +2,8 @@
 import-module au
 
 $releases = 'https://www.apple.com/itunes/download/win'
+$install_fname = 'bonjour.exe'
+$exeFile = Join-Path $env:TEMP $install_fname
 
 function global:au_SearchReplace {
 	@{
@@ -18,7 +20,7 @@ function global:au_SearchReplace {
 
 function global:au_BeforeUpdate($Package) {
 	$Latest.ChecksumType32 = $Latest.ChecksumType64 = "SHA256"
-	$Latest.Checksum32 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType32 -Url $Latest.URL32
+	$Latest.Checksum32 = (Get-FileHash -Path $exeFile -Algorithm $Latest.ChecksumType32).Hash.ToLower()
 	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType32 -Url $Latest.URL64
 }
 
@@ -30,10 +32,8 @@ function global:au_GetLatest {
 	$url32 = Get-RedirectedUrl -url "$($releases)32"
 	$url64 = Get-RedirectedUrl -url "$($releases)64"
 	$startdir = Get-Location
-	$install_fname = 'bonjour.exe'
 	Write-Output 'Download'
 	Set-Location $env:TEMP
-	$exeFile = Join-Path $env:TEMP $install_fname
 	$userAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome
 	Invoke-WebRequest -Uri $url32 -OutFile $exeFile -UserAgent $userAgent
 	$File = "$(get-location)\mDNSResponder.exe"

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -43,7 +43,7 @@ function global:au_GetLatest {
 	Write-Output "Version : $version"
 	Pop-Location
 	if($version -eq "3.1.0.1"){
-		$version = "3.1.0.4"
+		$version = "3.1.0.5"
 	}
 
 	$Latest = @{ URL32 = $url32; URL64 = $url64; Version = $version }

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -37,7 +37,7 @@ function global:au_GetLatest {
 	Invoke-WebRequest -Uri $url32 -OutFile $exeFile -UserAgent $userAgent
 	$File = "$(get-location)\mDNSResponder.exe"
 	7z.exe x $exeFile
-	7z.exe x "$(get-location)\bonjour*.msi"
+	7z.exe x "$(get-location)\Bonjour.msi"
 	Write-Output 'Get version'
 	$version=[System.Diagnostics.FileVersionInfo]::GetVersionInfo($File).FileVersion.trim().replace(',','.')
 	Write-Output "Version : $version"

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -31,9 +31,8 @@ function global:au_AfterUpdate($Package) {
 function global:au_GetLatest {
 	$url32 = Get-RedirectedUrl -url "$($releases)32"
 	$url64 = Get-RedirectedUrl -url "$($releases)64"
-	$startdir = Get-Location
 	Write-Output 'Download'
-	Set-Location $env:TEMP
+	Push-Location $env:TEMP
 	$userAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome
 	Invoke-WebRequest -Uri $url32 -OutFile $exeFile -UserAgent $userAgent
 	$File = "$(get-location)\mDNSResponder.exe"
@@ -42,7 +41,7 @@ function global:au_GetLatest {
 	Write-Output 'Get version'
 	$version=[System.Diagnostics.FileVersionInfo]::GetVersionInfo($File).FileVersion.trim().replace(',','.')
 	Write-Output "Version : $version"
-	Set-Location $startdir
+	Pop-Location
 	if($version -eq "3.1.0.1"){
 		$version = "3.1.0.4"
 	}

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -36,8 +36,8 @@ function global:au_GetLatest {
 	$userAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome
 	Invoke-WebRequest -Uri $url32 -OutFile $exeFile -UserAgent $userAgent
 	$File = "$(get-location)\mDNSResponder.exe"
-	7z.exe x $exeFile -i!"Bonjour.msi"
-	7z.exe x "$(get-location)\Bonjour.msi" -i!"mDNSResponder.exe"
+	7z.exe x $exeFile -i!"Bonjour.msi" -y
+	7z.exe x "$(get-location)\Bonjour.msi" -i!"mDNSResponder.exe" -y
 	Write-Output 'Get version'
 	$version=[System.Diagnostics.FileVersionInfo]::GetVersionInfo($File).FileVersion.trim().replace(',','.')
 	Write-Output "Version : $version"

--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -36,8 +36,8 @@ function global:au_GetLatest {
 	$userAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::Chrome
 	Invoke-WebRequest -Uri $url32 -OutFile $exeFile -UserAgent $userAgent
 	$File = "$(get-location)\mDNSResponder.exe"
-	7z.exe x $exeFile
-	7z.exe x "$(get-location)\Bonjour.msi"
+	7z.exe x $exeFile -i!"Bonjour.msi"
+	7z.exe x "$(get-location)\Bonjour.msi" -i!"mDNSResponder.exe"
 	Write-Output 'Get version'
 	$version=[System.Diagnostics.FileVersionInfo]::GetVersionInfo($File).FileVersion.trim().replace(',','.')
 	Write-Output "Version : $version"


### PR DESCRIPTION
Proposed changes in this pull request:
- Update script should be writing a versioned download URL for iTunes instead of a canonical URL to be redirected from.
  - The canoncial URL makes `bonjour` prone to breakage due to inevitable checksum changes when a new version of iTunes is released. A versioned URL should improve the package's long-term stability.
- Update script improvements:
  - Optimizes away an unnecessary download of the 32-bit installer during checksum calculation.
  - Limits the scope of files being extracted to those necessary for the update check.
  - Use `Push-Location` and `Pop-Location` instead of `Set-Location`. This should make it easier to revert to the previous directory should the script error out or stall for whatever reason.
  - Forcibly overwrite any older copies of those files, since TEMP is not guaranteed to have been cleaned between update runs. If they exist, 7z will otherwise stall with a run-time prompt asking the user to confirm the overwrite.
- Install script improvements:
  - Create a shim ignore file for `SetupAdmin.exe`. This is packaged with the iTunes installer, is not used by Bonjour, and is not used outside of an installation context. Package users don't need this shim.
  - Use `Install-ChocolateyInstallPackage` instead of `Install-ChocolateyPackage` for the Bonjour MSI's execution. The latter is not intended for files that are already present on your local system, and will otherwise print an error about an "attempt to use original download file name" failing.

- [x] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)
