### PR TITLE
chore: update mpc-qt to 26.01

### DIFF
--- a/automatic/mpc-qt/legal/VERIFICATION.txt
+++ b/automatic/mpc-qt/legal/VERIFICATION.txt
@@ -4,19 +4,19 @@ Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
 The embedded software has been downloaded from the listed download
-location on <https://github.com/mpc-qt/mpc-qt/releases/tag/v25.07>
+location on <https://github.com/mpc-qt/mpc-qt/releases/tag/v26.01>
 and can be verified by doing the following:
 
 1. Download the following:
 
-  url: <https://github.com/mpc-qt/mpc-qt/releases/download/v25.07/mpc-qt-win-x64-2507.zip>
+  url: <https://github.com/mpc-qt/mpc-qt/releases/download/v26.01/mpc-qt-win-x64-26.01.zip>
 
 2. You can obtain the checksum using one of the following methods:
   - Use powershell function 'Get-FileHash'
   - Use Chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum: ECBD1644B4AB867C7D6B2FB5B61C23C21CEACDD15A57F88768A668DBEA6C8204
+  checksum: 5AC479A8BA69BA838E4E02B2ABAA3496D9D35D52B690ECAE0F9276330044E0BF
 
 Using AU:
 

--- a/automatic/mpc-qt/mpc-qt.nuspec
+++ b/automatic/mpc-qt/mpc-qt.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>mpc-qt</id>
-    <version>25.07</version>
+    <version>26.01</version>
     <title>MPC QT</title>
     <authors>https://github.com/mpc-qt/mpc-qt/graphs/contributors</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Update MPC-QT to 26.01

**Previous version:** 25.07  
**New version:** 26.01  
**Release:** https://github.com/mpc-qt/mpc-qt/releases/tag/v26.01

### Changes
- Updated version in mpc-qt.nuspec
- Updated download URL and SHA256 checksum in VERIFICATION.txt
  - URL: `https://github.com/mpc-qt/mpc-qt/releases/download/v26.01/mpc-qt-win-x64-26.01.zip`
  - Checksum: `5ac479a8ba69ba838e4e02b2abaa3496d9d35d52b690ecae0f9276330044e0bf`

*Auto-generated by choco-auto-fixer*