### PR TITLE
fix: update actions/checkout to v4 in close-issue.yml

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -12,7 +12,7 @@ jobs:
       Github_personal_token: ${{ secrets.AU_GITHUB_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v4
       - name: Authenticate with GitHub
         run: |
           Install-Module PowerShellForGitHub -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Closing — actions/checkout@v6.0.2 existe bien. Diagnostic incorrect, cause des échecs à réinvestiguer.