### PR TITLE
fix(ddu): add desktop and start menu shortcuts after installation

### DIFF
--- a/automatic/ddu/tools/chocolateyInstall.ps1
+++ b/automatic/ddu/tools/chocolateyInstall.ps1
@@ -21,3 +21,10 @@ Remove-Item "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\*.exe"
 Remove-Item "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\DDU*" -Recurse
 
 Install-ChocolateyZipPackage @packageArgs
+
+# Create shortcuts so users can easily find the app
+$exePath = Get-ChildItem "$toolsDir\DDU*" -Filter "*.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($exePath) {
+    Install-ChocolateyShortcut -ShortcutFilePath "$env:Public\Desktop\DDU.lnk" -TargetPath $exePath.FullName -Description "Display Driver Uninstaller"
+    Install-ChocolateyShortcut -ShortcutFilePath "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\DDU.lnk" -TargetPath $exePath.FullName -Description "Display Driver Uninstaller"
+}


### PR DESCRIPTION
Closes #3963

## Problem
After installing `ddu`, no shortcut was created, making it difficult to find the application (reported by pmjm1234, Jan 4 2026).

## Solution
Added `Install-ChocolateyShortcut` calls after the zip extraction to create:
- Desktop shortcut: `%Public%\Desktop\DDU.lnk`
- Start Menu shortcut: `%ProgramData%\Microsoft\Windows\Start Menu\Programs\DDU.lnk`

Both point to the extracted DDU exe in the tools directory.