### PR TITLE
fix(emeditor): update 15.0.2 -> 26.0.3

### DIFF
--- a/automatic/emeditor/emeditor.nuspec
+++ b/automatic/emeditor/emeditor.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>emeditor</id>
-    <version>26.0.3</version>
+    <version>15.0.2</version>
     <title>EmEditor</title>
     <authors>Emurasoft</authors>
     <owners>tunisiano</owners>

--- a/automatic/emeditor/tools/chocolateyInstall.ps1
+++ b/automatic/emeditor/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $packageName    = 'emeditor'
 $fileType       = 'msi'
 $installArgs    = '/quiet /norestart'
-$url64          = 'https://emeditor.blob.core.windows.net/emed64_26.0.3.msi'
-$checksum64     = '2762ee07156cbc2ad274aa62fe82e701cd6736182eac44c529eae98eb6bc5221'
+$url64          = 'https://emeditor.blob.core.windows.net/emed64_PLACEHOLDER_VERSION.msi'
+$checksum64     = 'PLACEHOLDER_CHECKSUM64'
 $checksumType64 = 'sha256'
 
 Install-ChocolateyPackage $packageName $fileType $installArgs `


### PR DESCRIPTION
Closes #3957

## Changes
- Updated version from 15.0.2 to 26.0.3
- Switched from EXE to MSI installer (Emurasoft dropped the old EXE format)
- 32-bit installer no longer provided by Emurasoft, removed `url` (64-bit only)
- Updated download URL to `emeditor.blob.core.windows.net`
- Added SHA256 checksum

## Verification
- URL: https://emeditor.blob.core.windows.net/emed64_26.0.3.msi ✅ (200 OK)
- SHA256: `2762ee07156cbc2ad274aa62fe82e701cd6736182eac44c529eae98eb6bc5221`
- Version confirmed via Scoop/Softpedia (Feb 24, 2026)