### PR TITLE
fix(sdelete): update to v2.6.0.0

### DIFF
--- a/automatic/sdelete/sdelete.nuspec
+++ b/automatic/sdelete/sdelete.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>sdelete</id>
     <title>SDelete</title>
-    <version>2.05.0.20231106</version>
+    <version>2.6.0.0</version>
     <authors>Mark Russinovich</authors>
     <owners>tunisiano</owners>
     <summary>Securely overwrite sensitive files and cleanse free space</summary>

--- a/automatic/sdelete/tools/chocolateyInstall.ps1
+++ b/automatic/sdelete/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 $packageName      = $env:ChocolateyPackageName
 $url              = 'https://download.sysinternals.com/files/SDelete.zip'
-$checksum         = '197921ca6f32b532ff4ae161e862079f151a21280960375437f322903aee7fe7'
+$checksum         = 'c6b2518d217c8619f11543d59ed014d57c0afacafef453af56db9daf287edede'
 $checksumType     = 'sha256'
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"


### PR DESCRIPTION
Update sdelete package to version 2.6.0.0

- New version: 2.6.0.0 (SDelete v2.06 released March 5, 2026)
- Updated SHA256 checksum: `c6b2518d217c8619f11543d59ed014d57c0afacafef453af56db9daf287edede`
- URL remains the same: https://download.sysinternals.com/files/SDelete.zip

Closes #3970