### PR TITLE
Bot message : fix(belarc-advisor): update to v13.1

### DIFF
--- a/automatic/belarc-advisor/tools/ChocolateyInstall.ps1
+++ b/automatic/belarc-advisor/tools/ChocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$packageName    = 'belarc-advisor'
-$url            = 'http://www.belarc.com/Programs/advisorinstaller.exe'
+$url            = 'https://downloads.belarc.com/advisor/advisorinstaller.exe'
 $checksum       = '47EA898493F64ED818EDF9B76B0B0E047D753C3E1EBCFB70E251563D4212E56F'
 $checksumType   = 'sha256'
 

--- a/automatic/belarc-advisor/update.ps1
+++ b/automatic/belarc-advisor/update.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
 
-$url32 = "http://www.belarc.com/Programs/advisorinstaller.exe"
+$url32 = "https://downloads.belarc.com/advisor/advisorinstaller.exe"
 function global:au_SearchReplace {
     @{
         'tools\chocolateyInstall.ps1' = @{


### PR DESCRIPTION
Bot message : fix(belarc-advisor): update to v13.1

## Changes
- Updated download URL from HTTP redirect to direct HTTPS URL: `https://downloads.belarc.com/advisor/advisorinstaller.exe`
- Applied to both `update.ps1` and `tools/ChocolateyInstall.ps1`

## Package Status
- Current version: 13.1 (latest as of March 2026)
- Checksum verified: `47EA898493F64ED818EDF9B76B0B0E047D753C3E1EBCFB70E251563D4212E56F` (SHA256)
- AU update.ps1 pattern: ✅ working

Closes: chocolatey-community/chocolatey-package-requests#1600