### PR TITLE
fix: pin actions/checkout to v6.0.2 in improve_scripts.yml

### DIFF
--- a/.github/workflows/improve_scripts.yml
+++ b/.github/workflows/improve_scripts.yml
@@ -12,7 +12,7 @@ jobs:
         shell: powershell
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 100
 


### PR DESCRIPTION
Replace unpinned actions/checkout@master with the explicit version @v6.0.2. Using @master is a supply-chain security risk as it can pull unreviewed commits.

https://claude.ai/code/session_01WMgpbrDkWEXKq8EojjWyNu

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)
