### PR TITLE
fix: pin actions/checkout to v6.0.2 in sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ jobs:
   sonar:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0  # Historique complet pour Quality Gates
 


### PR DESCRIPTION
Replace actions/checkout@v6 (major version only) with the explicit patch version @v6.0.2, consistent with the rest of the repository workflows.

https://claude.ai/code/session_01WMgpbrDkWEXKq8EojjWyNu

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)
