### PR TITLE
chore: disable looknewer.ps1 in AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -209,7 +209,7 @@ build_script:
     scripts/ListPackages.ps1
     git commit -am "List packages"
     Write-host "Check broken package"
-    tools/looknewer.ps1
+    #tools/looknewer.ps1
     git commit -am "Broken packages"
     Write-host "Remove NoCheckChocoVersion"
     scripts/Remove-Nocheck.ps1


### PR DESCRIPTION
Comments out the call to tools/looknewer.ps1 to stop automatic GitHub issue creation from the scheduled AppVeyor build.

https://claude.ai/code/session_01WMgpbrDkWEXKq8EojjWyNu

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR as been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)
