### PR TITLE
fix: add chocolatey-core.extension before 7zip.install (CHO-26)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,9 +78,10 @@ install:
     $chocoVersion = if (($Env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null) -or ($ENV:APPVEYOR_PULL_REQUEST_NUMBER -eq '')) { $Env:choco_version } else { $Env:choco_version_pr }
     if (!(Test-Path "$env:nupkg_cache_path")) { $firstrun = "yes" }
     if (!(Test-Path "$env:nupkg_cache_path")) { mkdir -Force "$env:nupkg_cache_path" }
-    @{
-      '7zip.install' = '24.7.0'
+    [ordered]@{
       'chocolatey' = $chocoVersion
+      'chocolatey-core.extension' = '1.4.0'
+      '7zip.install' = '24.7.0'
       'chocolatey-misc-helpers.extension' = '0.0.4'
       'wormies-au-helpers' = '0.4.1'
       'checksum' = '0.3.1'


### PR DESCRIPTION
## Problème

`7zip.install 24.7.0` échoue lors du setup AppVeyor avec :
> "Get-AppInstallLocation" is not recognized as the name of a cmdlet...

## Analyse

- Le paquet `7zip.install 24.7.0` déclare dans son nuspec une dépendance sur `chocolatey-core.extension >= 1.3.3`
- Son `chocolateyInstall.ps1` appelle `Get-AppInstallLocation` (ligne 19) avec `$ErrorActionPreference = 'Stop'`
- `.appveyor.yml` installe tous les paquets cachés avec `--ignore-dependencies`, donc `chocolatey-core.extension` n'est jamais installé
- Résultat : exception lors de l'installation de `7zip.install` à chaque build (builds #8371 failed, #8378 affected)

## Fix

1. Ajout de `chocolatey-core.extension 1.4.0` dans la liste des paquets cachés
2. Passage de `@{}` à `[ordered]@{}` pour garantir que `chocolatey-core.extension` est installé **avant** `7zip.install`

## Test plan

- [ ] Vérifier que le prochain build AppVeyor installe `chocolatey-core.extension` sans erreur
- [ ] Vérifier que `7zip.install` s'installe correctement après
- [ ] Confirmer qu'il n'y a plus de `Get-AppInstallLocation` error dans les logs

Fixes CHO-26