### PR TITLE
fix(adwcleaner): add FileType='exe' to fix Get-RemoteFiles path error (CHO-28)

### DIFF
--- a/automatic/adwcleaner/update.ps1
+++ b/automatic/adwcleaner/update.ps1
@@ -26,7 +26,7 @@ function global:au_GetLatest {
 	Remove-Item $File -Force
 	Remove-Item "tools/*.exe" -ErrorAction SilentlyContinue
 
-	$Latest = @{ URL32 = $release; Checksum32 = $checksum; ChecksumType32 = $env:ChocolateyChecksumType; Version = $version }
+	$Latest = @{ URL32 = $release; Checksum32 = $checksum; ChecksumType32 = $env:ChocolateyChecksumType; Version = $version; FileType = 'exe' }
 	return $Latest
 }
 


### PR DESCRIPTION
## Problem

The `adwcleaner` AU check fails with:

```
Could not find a part of the path 'C:\projects\chocolatey-packages\automatic\adwcleaner\tools\adwcleaner.com\file\adwcleaner'
```

## Root Cause

`au_AfterUpdate` calls `Invoke-VirusTotalScan`, which calls `Get-RemoteFiles -NoSuffix` when `FileName32` is not pre-set.

`Get-RemoteFiles` uses the regex `(?<=\.)[^.]+$` to extract the file extension from the URL. For the URL `https://downloads.malwarebytes.com/file/adwcleaner` (no extension in path), the regex matches everything after the last dot — which falls in the **domain**, yielding `com/file/adwcleaner` as the "extension".

The resulting file name is `adwcleaner.com/file/adwcleaner`, which on Windows becomes the path `tools\adwcleaner.com\file\adwcleaner`. That directory chain doesn't exist → `DirectoryNotFoundException`.

## Fix

Add `FileType = 'exe'` to `$Latest` in `au_GetLatest`. This is the standard chocolatey-au mechanism to declare the file type when the URL contains no extension. `Get-RemoteFiles` checks `$Latest.FileType` first and uses it directly, so it correctly names the file `adwcleaner.exe` instead.

## Change

```diff
- $Latest = @{ URL32 = $release; Checksum32 = $checksum; ChecksumType32 = $env:ChocolateyChecksumType; Version = $version }
+ $Latest = @{ URL32 = $release; Checksum32 = $checksum; ChecksumType32 = $env:ChocolateyChecksumType; Version = $version; FileType = 'exe' }
```