### PR TITLE
fix: prevent null crash in Find-nextissueGH when issue title has no parentheses

### DIFF
--- a/scripts/Find-nextissueGH.ps1
+++ b/scripts/Find-nextissueGH.ps1
@@ -12,6 +12,15 @@ function Find-nextissueGH {
     Write-output $PSVersionTable
 
     "packageName : $packageName"
+
+    # Exit early if the issue title does not match the expected format.
+    # This guard must come BEFORE the Split call to avoid a null-valued expression
+    # crash when an issue title contains no parentheses.
+    if($packageName -notmatch 'update requested' -and $packageName -notmatch "package requested") {
+        "Not running the get-package script"
+        exit 0
+    }
+
     if($packageName -match "exclude") {
         $search = $packageName.substring(6).Split('(')[1].split(')')[0]
     } else {
@@ -19,11 +28,6 @@ function Find-nextissueGH {
     }
     "Package to import : $search"
     if($actor -ne 'tunisiano187') {
-        exit 0
-    }
-    if($packageName -notmatch 'update requested' -and $packageName -notmatch "package requested") {
-        "Not running the get-package script"
-        $search = $null
         exit 0
     }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `Find-nextissueGH` calls `$packageName.Split('(')[1].split(')')[0]` unconditionally. When any GitHub issue is opened with a title that does not contain `(`, `Split('(')` returns a 1-element array, `[1]` is `$null`, and the subsequent `.split(')')` call throws `You cannot call a method on a null-valued expression`.
- **Impact:** Every new issue opened in the repo that doesn't follow the `package requested (name)` / `update requested (name)` format causes the "Get new package" workflow to fail with exit code 1.
- **Fix:** Move the guard clause (`-notmatch 'update requested' -and -notmatch "package requested"`) to run **before** the `Split()` call so unrelated issues exit cleanly without touching string operations on potentially null values.

## Changed file

`scripts/Find-nextissueGH.ps1` — reordered early-exit check before the `Split('(')[1]` line.

## Test evidence

Recent failing run: https://github.com/tunisiano187/Chocolatey-packages/actions/runs/26293886013
Triggered by issue title: "Investigate and resolve GitHub CLI rate limiting for Chocolatey-packages" (no parentheses)