### PR TITLE
fix(ci): skip edited-issue workflow for non-actionable issue titles

### DIFF
--- a/.github/workflows/edited-issue.yml
+++ b/.github/workflows/edited-issue.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validation:
-    if: ${{ github.event.issue.state == 'open' }}
+    if: ${{ github.event.issue.state == 'open' && (contains(github.event.issue.title, 'exclude') || contains(github.event.issue.title, 'remove') || contains(github.event.issue.title, 'block')) }}
     runs-on: windows-2025
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,3 +99,18 @@ Packages are updated daily in AppVeyor. The `au_Push = 'true'` environment varia
 
 ### Linting
 `PSScriptAnalyzerSettings.psd1` excludes `PSAvoidGlobalVars` and `PSUseShouldProcessForStateChangingFunctions` (both intentionally used by AU's global function pattern).
+
+## Daily Session Task
+
+At the start of every session, automatically perform the following routine:
+
+1. **Check open GitHub issues** on `tunisiano187/Chocolatey-packages` (exclude the Dependency Dashboard, issue #3784).
+   - For each actionable issue found: investigate, implement a fix, and open a PR. Never push directly to master.
+2. **If no actionable issues exist**: check the most recent CI workflow run for failures (GitHub Actions).
+   - For each CI failure found: diagnose the root cause, fix it, and open a PR.
+3. **Always use PRs** — never commit fixes directly to master.
+4. **Save updates to this task**: if the user provides a remark, correction, or addition to this daily task definition during a session, append it to this section in CLAUDE.md and commit it.
+
+### Task history / amendments
+<!-- Append user amendments below this line, with date -->
+- 2026-06-03: Task created. Exclude Dependency Dashboard (#3784) from issue analysis.


### PR DESCRIPTION
## Summary

- Le workflow `edited-issue.yml` ("Check exception") se déclenchait sur **toute** édition d'issue, y compris quand `renovate[bot]` met à jour le Dependency Dashboard.
- `Block-package.ps1` lève alors une exception car le titre `"Dependency Dashboard"` ne contient ni `exclude`, ni `remove`, ni `block` — provoquant 2 échecs CI par jour.
- **Fix** : ajout d'un filtre `contains()` sur le titre dans la condition `if` du job, afin que le workflow ne s'exécute que pour les issues d'exception réelles.

## Cause

```
Exception: Block-package.ps1:22
  throw "User renovate[bot] cannot run this"
```

Le titre `"Dependency Dashboard"` ne matchait aucun mot-clé, donc le script jetait une exception pour tout acteur.

## Test plan

- [ ] Vérifier que le workflow ne se déclenche plus quand `renovate[bot]` édite le Dependency Dashboard
- [ ] Vérifier qu'il s'exécute toujours correctement pour les issues avec "exclude", "remove" ou "block" dans le titre

https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_