### PR TITLE
fix: skip Check exception job when triggered by renovate[bot]

### DIFF
--- a/.github/workflows/edited-issue.yml
+++ b/.github/workflows/edited-issue.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validation:
-    if: ${{ github.event.issue.state == 'open' && (contains(github.event.issue.title, 'exclude') || contains(github.event.issue.title, 'remove') || contains(github.event.issue.title, 'block')) }}
+    if: ${{ github.actor != 'renovate[bot]' && github.event.issue.state == 'open' && (contains(github.event.issue.title, 'exclude') || contains(github.event.issue.title, 'remove') || contains(github.event.issue.title, 'block')) }}
     runs-on: windows-2025
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The `Check exception` CI job was failing repeatedly when `renovate[bot]` edited an issue whose title matched the `exclude`/`remove`/`block` filter.
- `Block-package.ps1` intentionally throws (`throw "User $actor cannot run this"`) for unauthorized actors, which exits with code 1 and marks the job as **failed** instead of skipped.
- Fix: prepend `github.actor != 'renovate[bot]'` to the job's `if` condition so the job is simply **skipped** when renovate triggers the workflow.

## Root cause (from CI logs)

```
Block-package -title "Dependency Dashboard" -issueNumber 3784 -actor "renovate[bot]"
Exception: Block-package.ps1:22 → throw "User renovate[bot] cannot run this"
Error: Process completed with exit code 1.
```

Affected runs: [26892637111](https://github.com/tunisiano187/Chocolatey-packages/actions/runs/26892637111), [26882965923](https://github.com/tunisiano187/Chocolatey-packages/actions/runs/26882965923)

## Test plan

- [ ] Merge and verify that the next time `renovate[bot]` edits an issue the `Check exception` job shows as **skipped** (not failed)
- [ ] Verify that a legitimate `tunisiano187`-authored edit on a matching issue still triggers and runs the job correctly

https://claude.ai/code/session_01RgADoH7PSQkwVj8WFK8773

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgADoH7PSQkwVj8WFK8773)_