### PR TITLE
fix: exit gracefully in Block-package when actor is unauthorized

### DIFF
--- a/scripts/Block-package.ps1
+++ b/scripts/Block-package.ps1
@@ -19,7 +19,7 @@ function Block-Package {
     )
     Write-Output $actor
     if(($actor -ne 'tunisiano187' -and $actor -ne 'github-actions[bot]') -or ($title.ToLower() -notmatch 'exclude' -and $title.ToLower() -notmatch 'remove' -and $title.ToLower() -notmatch 'block')) {
-      throw "User $actor cannot run this"
+      Write-Warning "User $actor cannot run this - skipping"; return
     }
     $ErrorActionPreference = 'Stop';
 

--- a/scripts/Block-package.ps1
+++ b/scripts/Block-package.ps1
@@ -19,7 +19,8 @@ function Block-Package {
     )
     Write-Output $actor
     if(($actor -ne 'tunisiano187' -and $actor -ne 'github-actions[bot]') -or ($title.ToLower() -notmatch 'exclude' -and $title.ToLower() -notmatch 'remove' -and $title.ToLower() -notmatch 'block')) {
-      Write-Warning "User $actor cannot run this - skipping"; return
+      Write-Warning "User $actor cannot run this - skipping"
+      return
     }
     $ErrorActionPreference = 'Stop';
 


### PR DESCRIPTION
## Summary

- `Block-package.ps1` line 22 used `throw` when the actor or title didn't meet the conditions, causing the CI job to exit with code 1 (failure).
- Replace `throw` with `Write-Warning` + `return` so the function exits cleanly (exit 0) when conditions aren't met — the job stops without failing.

## Change

```powershell
# Before
throw "User $actor cannot run this"

# After
Write-Warning "User $actor cannot run this - skipping"; return
```

## Test plan

- [x] Merge and verify that the next "Check exception" run triggered by an unauthorized actor completes with ✅ instead of ❌

https://claude.ai/code/session_01RgADoH7PSQkwVj8WFK8773

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgADoH7PSQkwVj8WFK8773)_