### PR TITLE
fix(bonjour): replace em dash with ASCII hyphen to fix parse error

### DIFF
--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -23,7 +23,7 @@ function global:au_BeforeUpdate($Package) {
 	if (Test-Path $exeFile) {
 		$Latest.Checksum32 = (Get-FileHash -Path $exeFile -Algorithm $Latest.ChecksumType32).Hash.ToLower()
 	} else {
-		throw "iTunes installer not found at '$exeFile' — download may have failed."
+		throw "iTunes installer not found at '$exeFile' - download may have failed."
 	}
 	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType64 -Url $Latest.URL64
 }


### PR DESCRIPTION
## Summary

- **Root cause**: line 26 of `automatic/bonjour/update.ps1` contained a Unicode em dash `—` (U+2014) in a `throw` string, causing PowerShell to fail with `Unexpected token 'download' in expression or statement`.
- **Fix**: replaced the em dash with a standard ASCII hyphen `-`.

Closes [CHO-407](/CHO/issues/CHO-407)

## Test plan

- [ ] AppVeyor CI picks up the change; `bonjour` updater runs without parse error on the next AU cycle.