### PR TITLE
fix(freeplane): prevent download.exe path regression (CHO-408, 3rd occurrence)

### DIFF
--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -15,14 +15,10 @@ function global:au_SearchReplace {
 
 function global:au_BeforeUpdate {
 	Invoke-WebRequest -Uri "https://raw.githubusercontent.com/freeplane/freeplane/1.12.x/license.txt" -OutFile "legal\LICENSE.txt"
-	# SourceForge URLs end with /download; extract the actual .exe filename from the second-to-last path segment
-	$urlSegments = ([uri]$Latest.URL32).AbsolutePath -split '/' | Where-Object { $_ }
-	$cleanFileName = if ($urlSegments[-1] -eq 'download') {
-		[uri]::UnescapeDataString($urlSegments[-2])
-	} else {
-		[System.IO.Path]::GetFileName(([uri]$Latest.URL32).LocalPath)
-	}
-	$destPath = "tools\$cleanFileName"
+	# Clean any stale installer files or directories from previous runs (prevents CHO-113/CHO-378/CHO-408 recurrence)
+	Get-ChildItem 'tools' -Filter '*.exe' -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+	# Use a fixed filename to avoid SourceForge URL path-segment parsing issues
+	$destPath = 'tools\freeplane-setup.exe'
 	Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
 	$Latest.ChecksumType32 = 'sha512'
@@ -35,7 +31,7 @@ function global:au_AfterUpdate($Package) {
 function global:au_GetLatest {
 	[xml]$rss = Invoke-WebRequest -Uri $releases | Select-Object -ExpandProperty Content
 	$items = $rss.rss.channel.item | Where-Object {
-		($_.title -like "*-Setup-with*.exe*") -or ($_.link -like "*Freeplane-Setup*.exe*")
+		($_.title -like "*-Setup-with*.exe*") -or ($_.link -like "*Freeplane-Setup*.exe*") -or ($_.link -like '*.exe/download')
 	} | Select-Object -First 1
 
 	$url32 = $items.link


### PR DESCRIPTION
## Problem

Build #8573 (2026-06-05) fails in `au_BeforeUpdate` with:

> Could not find a part of the path 'tools\download.exe\download'

This is the **3rd occurrence** of this pattern (CHO-113, CHO-378, CHO-408). Previous fixes added URL path-segment extraction logic, but the root cause was never fully eliminated.

## Root cause

`au_BeforeUpdate` extracted the installer filename from the SourceForge URL's second-to-last path segment. When the URL contains `download.exe` as a literal path segment (a SourceForge generic redirect pattern), `$cleanFileName` becomes `download.exe`. On subsequent runs, if a `tools\download.exe` directory exists from a prior botched run, `Invoke-WebRequest -OutFile tools\download.exe` appends `download` (from the URL's last segment) → `tools\download.exe\download` → error.

## Fix

- **Remove URL-based filename detection entirely** — download to fixed path `tools\freeplane-setup.exe`. `chocolateyInstall.ps1` already uses `Get-Item $toolsPath\*.exe` so the name doesn't matter.
- **Clean stale `*.exe` files/directories** before download to prevent directory collision.
- **Broaden RSS filter** to include `*.exe/download` as a fallback so `$items` is never null.

## Testing

`chocolateyInstall.ps1` uses `Get-Item $toolsPath\*.exe` — works with any filename.
`au_SearchReplace` updates VERIFICATION.txt with URL + checksum only — not filename-dependent.