### PR TITLE
fix(dual-monitor-tools): prevent illegal characters in path regression (CHO-409)

### DIFF
--- a/automatic/dual-monitor-tools/update.ps1
+++ b/automatic/dual-monitor-tools/update.ps1
@@ -15,12 +15,13 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate {
-	. ..\..\scripts\Get-FileVersion.ps1
-	$FileVersion = Get-FileVersion $Latest.URL32 -keep
-	$cleanFileName = [System.IO.Path]::GetFileName([uri]::new($Latest.URL32).LocalPath)
-	Move-Item -Path $FileVersion.TempFile -Destination "tools\$cleanFileName"
-	$Latest.Checksum32 = $FileVersion.Checksum
-	$Latest.ChecksumType32 = $FileVersion.checksumType
+	# Remove any stale MSI files from previous runs (prevents CHO-112/CHO-377/CHO-409 recurrence)
+	Get-ChildItem 'tools' -Filter '*.msi' -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
+	# Use a version-derived fixed filename to avoid SourceForge URL special-character issues with WebClient
+	$destPath = "tools\DualMonitorTools-$($Latest.Version).msi"
+	Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing
+	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
+	$Latest.ChecksumType32 = 'sha512'
 }
 
 function global:au_AfterUpdate($Package) {


### PR DESCRIPTION
## Summary

- Replaces `Get-FileVersion`/`WebClient.DownloadFile` with `Invoke-WebRequest` in `au_BeforeUpdate`
- Uses a version-derived fixed filename (`DualMonitorTools-{version}.msi`) instead of parsing it from the SourceForge URL
- Adds cleanup of stale MSI files from previous runs

## Root cause

SourceForge redirect URLs can contain special characters (`?`, `=`, `&` in path segments, or mirror-name brackets) that cause .NET `WebClient.DownloadFile` — called internally by `Get-WebFileName` inside `Get-FileVersion` — to throw _"Illegal characters in path"_. This is the 3rd recurrence of this pattern (CHO-112 → CHO-377 → CHO-409).

The fix mirrors what was applied to freeplane in CHO-408: bypass `Get-FileVersion`/WebClient entirely in favour of `Invoke-WebRequest` (which handles SourceForge redirects reliably) and a stable, version-keyed filename.

## Test plan

- [ ] AU update runs without "Illegal characters in path" error
- [ ] `tools\DualMonitorTools-{version}.msi` is created correctly
- [ ] Checksum written to `legal\VERIFICATION.txt` is a valid SHA512
- [ ] `chocolateyinstall.ps1` `Get-ChildItem $toolsDir\DualMonitorTools-*.msi` finds the file

Fixes CHO-409 (3rd occurrence; see also CHO-377, CHO-112)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)