### PR TITLE
fix(pngquant): pin nuspec to 3.0.3 to prevent AU downgrade push (CHO-411)

### DIFF
--- a/automatic/pngquant/pngquant.nuspec
+++ b/automatic/pngquant/pngquant.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>pngquant</id>
-    <version>2.17.0</version>
+    <version>3.0.3</version>
     <title>pngquant</title>
     <authors>Kornel Lesiński</authors>
     <owners>tunisiano</owners>
@@ -19,6 +19,10 @@ and for PlayStation 2 development, where one of the texture formats is RGBA-pale
 PNG-compressed). This is the same technique used for many of the images on the Miscellaneous Transparent
 PNGs page (http://www.libpng.org/pub/png/pngs-img.html), and the results are often indistinguishable from
 the original, truecolor PNG images.
+
+**Note:** The upstream Windows binary at pngquant.org may lag behind the Linux/macOS version.
+The installed `pngquant.exe` reports the actual Windows build version, which may differ from
+the package version number until upstream publishes a new Windows build.
 
 ### Package-specific issue
 If this package isn't up-to-date for some days, [Create an issue](https://github.com/tunisiano187/Chocolatey-packages/issues/new/choose)


### PR DESCRIPTION
## Problem

The `pngquant` Chocolatey package has a version mismatch: Chocolatey community shows 3.0.3 (published 2026-05-17), but the Windows binary at `https://pngquant.org/pngquant-windows.zip` is 2.17.0 (September 2021). The local nuspec was previously set to 2.17.0 as a correction, but this means AU would detect 2.17.0 from the binary, see versions match, and potentially push a "downgrade" that Chocolatey would reject.

## Fix

- **Pin nuspec version to 3.0.3** — matching the current Chocolatey community version
- **Add description note** — informs users that the Windows binary may lag behind the advertised Linux/macOS version

## Why this is safe

With nuspec at 3.0.3, `au_GetLatest` returns 2.17.0 (from the actual Windows binary). Since `2.17.0 < 3.0.3`, AU treats it as "no newer version available" and skips the push — preventing a downgrade attempt. When upstream eventually releases a real Windows 3.0.3 build, the detection logic will correctly return 3.0.3 and AU will update checksums normally.

## References

- Issue: CHO-411
- Triage: TRIAGE_PNGQUANT.md