### PR TITLE
fix(backupper-server): normalize 4-part PE version to 3-part to stop 409 push loop (CHO-423)

### DIFF
--- a/automatic/backupper-server/update.ps1
+++ b/automatic/backupper-server/update.ps1
@@ -32,9 +32,18 @@ function global:au_GetLatest {
   # PowerShell Invoke-WebRequest. The permanent CDN URL always serves the latest installer.
   . ..\..\scripts\Get-FileVersion.ps1
   $FileVersion = Get-FileVersion $url32
-  $version = $FileVersion.Version
+  $v = [version]$FileVersion.Version
 
-  if (-not $version) { throw "Could not extract version from $url32" }
+  if (-not $v) { throw "Could not extract version from $url32" }
+
+  # PE FileVersionInfo returns 4-part versions (e.g. 8.3.0.0).
+  # Normalize to 3-part when revision is 0 so AU matches the nuspec/chocolatey.org format
+  # and does not attempt a redundant push that results in a 409 Conflict.
+  $version = if ($v.Revision -le 0) {
+      '{0}.{1}.{2}' -f $v.Major, $v.Minor, $v.Build
+  } else {
+      $v.ToString()
+  }
 
   return @{ URL32 = $url32; Version = $version }
 }


### PR DESCRIPTION
## Root cause

`au_GetLatest` calls `Get-FileVersion` which extracts the version from the installer's PE `FileVersionInfo`. PE files return 4-part versions (e.g. `8.3.0.0`). AU stringifies this as `"8.3.0.0"` and compares it against the nuspec's `"8.3.0"` — different strings → AU considers an update is needed → pushes → chocolatey.org rejects with **409 Conflict** because `8.3.0` is already published.

## Fix

Normalize the `[System.Version]` object in `au_GetLatest`: when the revision component is `0`, format as `major.minor.build` (3 parts). This matches the format chocolatey.org uses and lets AU's version equality check work correctly, stopping the spurious push loop.

## Verification

After merge, the next AU run should return `"8.3.0"` from `au_GetLatest`, match the nuspec, and skip — no 409 conflict.

Fixes CHO-423