### PR TITLE
fix(freeplane): tighten RSS filter, dynamic license branch, clean old .exe (CHO-425)

### DIFF
--- a/automatic/backupper-server/update.ps1
+++ b/automatic/backupper-server/update.ps1
@@ -32,9 +32,18 @@ function global:au_GetLatest {
   # PowerShell Invoke-WebRequest. The permanent CDN URL always serves the latest installer.
   . ..\..\scripts\Get-FileVersion.ps1
   $FileVersion = Get-FileVersion $url32
-  $version = $FileVersion.Version
+  $v = [version]$FileVersion.Version
 
-  if (-not $version) { throw "Could not extract version from $url32" }
+  if (-not $v) { throw "Could not extract version from $url32" }
+
+  # PE FileVersionInfo returns 4-part versions (e.g. 8.3.0.0).
+  # Normalize to 3-part when revision is 0 so AU matches the nuspec/chocolatey.org format
+  # and does not attempt a redundant push that results in a 409 Conflict.
+  $version = if ($v.Revision -le 0) {
+      '{0}.{1}.{2}' -f $v.Major, $v.Minor, $v.Build
+  } else {
+      $v.ToString()
+  }
 
   return @{ URL32 = $url32; Version = $version }
 }

--- a/automatic/dual-monitor-tools/update.ps1
+++ b/automatic/dual-monitor-tools/update.ps1
@@ -34,6 +34,7 @@ function global:au_GetLatest {
 	$xml = Get-Content $File
 	$links=$xml | Where-Object {$_ -match '.msi/download'} | Select-Object -First 1
 	$url32 = Get-RedirectedUrl ($links.Split('<|>') | Where-Object {$_ -match '.msi/download'})
+	$url32 = [uri]::EscapeUriString($url32)
 	$version = (Get-Version $url32).Version
 
 	$Latest = @{ URL32 = $url32; Version = $version }

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -14,8 +14,19 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate {
-	Invoke-WebRequest -Uri "https://raw.githubusercontent.com/freeplane/freeplane/1.12.x/license.txt" -OutFile "legal\LICENSE.txt"
-	# SourceForge URLs end with /download; extract the actual .exe filename from the second-to-last path segment
+	# Update license from the current stable branch
+	$version = $Latest.Version
+	$majorMinor = ($version -split '\.')[0..1] -join '.'
+	$licenseBranch = "$majorMinor.x"
+	try {
+		Invoke-WebRequest -Uri "https://raw.githubusercontent.com/freeplane/freeplane/$licenseBranch/license.txt" -OutFile "legal\LICENSE.txt" -UseBasicParsing -ErrorAction Stop
+	} catch {
+		# Fall back to 1.12.x if the branch-specific URL fails
+		Invoke-WebRequest -Uri "https://raw.githubusercontent.com/freeplane/freeplane/1.12.x/license.txt" -OutFile "legal\LICENSE.txt" -UseBasicParsing
+	}
+	# Clean up any old installer files before downloading the new one
+	Get-ChildItem "tools\*.exe" -ErrorAction SilentlyContinue | Remove-Item -Force
+	# SourceForge URLs end with /download; extract the .exe filename from the second-to-last path segment
 	$urlSegments = ([uri]$Latest.URL32).AbsolutePath -split '/' | Where-Object { $_ }
 	$cleanFileName = if ($urlSegments[-1] -eq 'download') {
 		[uri]::UnescapeDataString($urlSegments[-2])
@@ -34,16 +45,16 @@ function global:au_AfterUpdate($Package) {
 
 function global:au_GetLatest {
 	[xml]$rss = Invoke-WebRequest -Uri $releases | Select-Object -ExpandProperty Content
+	# Select the standard (non-touchscreen, non-archive) Setup .exe
 	$items = $rss.rss.channel.item | Where-Object {
-		($_.title -like "*-Setup-with*.exe*") -or ($_.link -like "*Freeplane-Setup*.exe*")
+		($_.link -like "*Freeplane-Setup-[0-9]*.exe/download*") -and
+		($_.link -notlike "*/archive/*") -and
+		($_.link -notlike "*touchscreen*")
 	} | Select-Object -First 1
 
 	$url32 = $items.link
-	$version = ($url32.Split('-|/') | Where-Object {$_ -match ".exe"}).replace('.exe','').replace('u','-u')
-
-	if($version -eq "1.11.12") {
-		$version = "1.11.12.202442901"
-	}
+	$versionMatch = [regex]::Match($url32, 'Freeplane-Setup-(\d+\.\d+(?:\.\d+)?(?:-u\d+)?)\.exe')
+	$version = $versionMatch.Groups[1].Value
 
 	$Latest = @{ URL32 = $url32; Version = $version }
 	return $Latest


### PR DESCRIPTION
## Summary

- **RSS filter hardened**: selects only `Freeplane-Setup-[0-9]*.exe` (non-touchscreen, non-archive); previously the touchscreen/archive variant was matched first in RSS order, so the wrong installer was being downloaded and verified.
- **License branch dynamic**: derived from the package version (e.g. `1.13.x`) instead of hardcoded `1.12.x`; fallback to `1.12.x` if branch fetch fails.
- **Old .exe cleanup**: `tools\*.exe` files are removed before downloading to prevent `chocolateyInstall.ps1` from finding multiple `.exe` files across version updates.
- **Cleaner version extraction**: uses an explicit regex `Freeplane-Setup-(\d+\.\d+...)\.exe` instead of a character-split + string-replace chain.

The root `DirectoryNotFoundException` (path containing `download.exe/download`) was already fixed in CHO-378 / f2c31f6e8 by bypassing `Get-FileVersion`. This PR closes out the remaining issues observed in AppVeyor builds #8583–#8584.

## Test plan

- [ ] Verify `.\update.ps1` selects the correct non-touchscreen URL from the SourceForge RSS
- [ ] Verify version parses correctly as `1.13.2` (or current latest)
- [ ] Verify `tools\*.exe` cleanup runs before download in `au_BeforeUpdate`
- [ ] AppVeyor CI passes without `DirectoryNotFoundException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)