### PR TITLE
fix(projectlibre): upgrade SourceForge redirect URL from HTTP to HTTPS (CHO-427)

### DIFF
--- a/automatic/projectlibre.install/update.ps1
+++ b/automatic/projectlibre.install/update.ps1
@@ -18,7 +18,7 @@ function global:au_AfterUpdate($Package) {
 
 function global:au_GetLatest {
 	# SourceForge latest/download redirects to the jar file URL which contains the version
-	$redirectUrl = Get-RedirectedUrl 'http://sourceforge.net/projects/projectlibre/files/latest/download'
+	$redirectUrl = Get-RedirectedUrl 'https://sourceforge.net/projects/projectlibre/files/latest/download'
 	if (-not $redirectUrl) {
 		throw "Could not follow SourceForge redirect"
 	}

--- a/automatic/projectlibre.portable/update.ps1
+++ b/automatic/projectlibre.portable/update.ps1
@@ -19,7 +19,7 @@ function global:au_AfterUpdate($Package) {
 
 function global:au_GetLatest {
 	# SourceForge latest/download redirects to the jar file URL which contains the version
-	$redirectUrl = Get-RedirectedUrl 'http://sourceforge.net/projects/projectlibre/files/latest/download'
+	$redirectUrl = Get-RedirectedUrl 'https://sourceforge.net/projects/projectlibre/files/latest/download'
 	if (-not $redirectUrl) {
 		throw "Could not follow SourceForge redirect"
 	}

--- a/automatic/projectlibre/update.ps1
+++ b/automatic/projectlibre/update.ps1
@@ -1,7 +1,7 @@
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
 
-$releases = 'http://sourceforge.net/projects/projectlibre/files/latest/download'
+$releases = 'https://sourceforge.net/projects/projectlibre/files/latest/download'
 
 function global:au_SearchReplace {
 	@{


### PR DESCRIPTION
## Summary

- Upgrades the SourceForge `latest/download` redirect URL from `http://` to `https://` in all three projectlibre variant update scripts
- Files changed: `automatic/projectlibre/update.ps1`, `automatic/projectlibre.install/update.ps1`, `automatic/projectlibre.portable/update.ps1`
- Pure URL scheme change — no logic modifications

## Test plan

- [ ] CI updater run passes for `projectlibre`, `projectlibre.install`, and `projectlibre.portable`
- [ ] Version scraping via HTTPS redirect works as expected

Closes CHO-427

🤖 Generated with [Claude Code](https://claude.com/claude-code)