### PR TITLE
fix(slade): filter GitHub-only hrefs to avoid space-concatenated URL error (CHO-432)

### DIFF
--- a/automatic/slade/update.ps1
+++ b/automatic/slade/update.ps1
@@ -19,10 +19,15 @@ function global:au_AfterUpdate($Package) {
 
 function global:au_GetLatest {
     $page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $urls = $page.Links | Where-Object { $_.href -match '.7z' } | Where-Object { $_.href -notmatch 'winxp|tools|beta' } | Select-Object -ExpandProperty href -Unique
-    $url32 = "https://slade.mancubus.net/$($urls | Where-Object { $_ -notmatch 'x64' })"
-    $url64 = "https://slade.mancubus.net/$($urls | Where-Object { $_ -match 'x64' })"
-    $version = (Get-Version $url32).Version
+    # Filter to absolute GitHub release URLs only to avoid concatenating relative + absolute hrefs
+    $urls = $page.Links |
+        Where-Object { $_.href -match '\.7z' } |
+        Where-Object { $_.href -notmatch 'winxp|tools|beta' } |
+        Where-Object { $_.href -match 'github\.com' } |
+        Select-Object -ExpandProperty href -Unique
+    # Package ships 64-bit only; URL32 slot is used for the x64 archive
+    $url64 = $urls | Where-Object { $_ -match 'x64' } | Select-Object -First 1
+    $version = (Get-Version $url64).Version
     @{
         Version      = $version
         URL32        = $url64


### PR DESCRIPTION
## Problem

The AU update run (AppVeyor build 8588) fails with:
```
URL syntax is invalid:https://slade.mancubus.net/files/3.2.12/slade_3.2.12_x64.7z https://github.com/sirjuddington/SLADE/releases/download/3.2.12/slade_3.2.12_x64.7z
```

The download page lists each `.7z` file twice: once as a relative href and once as an absolute GitHub URL. After `Select-Object -ExpandProperty href -Unique` both variants survive the filter and are string-interpolated into a single space-separated invalid URL.

## Fix

- Add `-match 'github\.com'` filter to keep only absolute GitHub release URLs
- Use `Select-Object -First 1` to guard against future duplicates
- Extract version from x64 GitHub URL directly

Related: CHO-432