### PR TITLE
fix(pwgen): use Get-FileVersion to avoid SourceForge /download path error (CHO-433, CHO-434)

### DIFF
--- a/automatic/pwgen.install/update.ps1
+++ b/automatic/pwgen.install/update.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
+. ..\..\scripts\Get-FileVersion.ps1
 
 $releases = 'https://sourceforge.net/projects/pwgen-win/rss?path=/Password%20Tech'
 
@@ -22,12 +23,31 @@ function global:au_GetLatest {
 	$File = "$env:TEMP\pwgen.install.xml"
 	Invoke-WebRequest -Uri $releases -OutFile $File
 	$xml = Get-Content $File
-	$links=$xml | Where-Object {$_ -match 'Setup.exe/download'} | Where-Object {$_ -match 'link'}  | Select-Object -First 1
-	$url32 = $links.Split('<|>') | Where-Object {$_ -match 'download'}
+
+	# RSS is newest-first; grab the first Setup.exe entry
+	$links = $xml | Where-Object { $_ -match 'Setup\.exe/download' } | Where-Object { $_ -match 'link' } | Select-Object -First 1
+	$url32 = ($links.Split('<|>') | Where-Object { $_ -match '/download' })[0]
+
+	if (-not $url32) {
+		throw "Could not find Setup.exe download link in RSS feed"
+	}
+
 	$version = (Get-Version $url32).Version
 
-	$Latest = @{ URL32 = $url32; Version = $version }
+	# Use Get-FileVersion to compute checksum without bundling the installer; Get-FileVersion
+	# uses the second-to-last URL segment as filename, which is the real exe name, avoiding
+	# the /download suffix path error that -ChecksumFor 32 triggers.
+	$fileInfo = Get-FileVersion $url32
+	$checksum = $fileInfo.Checksum
+	$checksumType = $fileInfo.ChecksumType
+
+	$Latest = @{
+		URL32          = $url32
+		Version        = $version
+		Checksum32     = $checksum
+		ChecksumType32 = $checksumType
+	}
 	return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor none

--- a/automatic/pwgen.portable/update.ps1
+++ b/automatic/pwgen.portable/update.ps1
@@ -1,8 +1,9 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
+. ..\..\scripts\Get-FileVersion.ps1
 
-$releases = 'https://sourceforge.net/projects/pwgen-win/files/Password%20Tech/'
+$releases = 'https://sourceforge.net/projects/pwgen-win/rss?path=/Password%20Tech'
 
 function global:au_SearchReplace {
 	@{
@@ -22,11 +23,35 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$version = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_.href -match "Tech\/"} | Where-Object {$_.href -notmatch 'css'}).href[0].split('/')[-2]
-	$url = "https://sourceforge.net/projects/pwgen-win/files/Password%20Tech/$version/PwTech-$version-portable.zip/download"
+	$File = "$env:TEMP\pwgen.portable.xml"
+	Invoke-WebRequest -Uri $releases -OutFile $File
+	$xml = Get-Content $File
 
-	$Latest = @{ URL32 = $url; URL64 = $url; Version = $version }
+	# RSS is newest-first; grab the first portable.zip entry
+	$links = $xml | Where-Object { $_ -match 'portable\.zip/download' } | Where-Object { $_ -match 'link' } | Select-Object -First 1
+	$url = ($links.Split('<|>') | Where-Object { $_ -match '/download' })[0]
+
+	if (-not $url) {
+		throw "Could not find portable.zip download link in RSS feed"
+	}
+
+	$version = (Get-Version $url).Version
+
+	# Use Get-FileVersion to compute checksum without bundling the file in the package
+	$fileInfo = Get-FileVersion $url
+	$checksum = $fileInfo.Checksum
+	$checksumType = $fileInfo.ChecksumType
+
+	$Latest = @{
+		URL32          = $url
+		URL64          = $url
+		Version        = $version
+		Checksum32     = $checksum
+		ChecksumType32 = $checksumType
+		Checksum64     = $checksum
+		ChecksumType64 = $checksumType
+	}
 	return $Latest
 }
 
-update
+update -ChecksumFor none


### PR DESCRIPTION
## Problem

Both `pwgen.portable` and `pwgen.install` fail in the AU update run with:
```
Repeating pwgen.portable (1): ... Could not find a part of the path 'tools/download.zip/download'
Repeating pwgen.install (2): ... Could not find a part of the path 'tools/download.exe/download'
```

## Root Cause

AU's automatic checksum download (`-ChecksumFor 32/all`) uses the last URL path segment as the local filename. For SourceForge URLs ending in `.../file.zip/download`, the last segment is `download`, giving AU a local path like `tools\download.zip`. On retry AU tries to open `tools\download.zip\download` as a file, which fails.

## Fix

Switch to `Get-FileVersion` for explicit checksum computation. It already handles SourceForge URLs by using the **second-to-last** path segment as the temp filename (e.g. `PwTech-3.6.0-portable.zip`), so the path is always correct. Then call `update -ChecksumFor none`.

**Additional fixes:**
- `pwgen.portable`: switch version detection from directory-page scrape (`.href[0]` picked the oldest version) to RSS-based detection (first RSS item = newest version)
- Both: add a guard `throw` if no download link is found in the RSS feed

Related: [CHO-433](/CHO/issues/CHO-433), [CHO-434](/CHO/issues/CHO-434)