### PR TITLE
fix(tigervnc): remove Get-RedirectedUrl to fix SourceForge CDN path error (CHO-435)

### DIFF
--- a/automatic/pwgen.install/update.ps1
+++ b/automatic/pwgen.install/update.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
+. ..\..\scripts\Get-FileVersion.ps1
 
 $releases = 'https://sourceforge.net/projects/pwgen-win/rss?path=/Password%20Tech'
 
@@ -22,12 +23,31 @@ function global:au_GetLatest {
 	$File = "$env:TEMP\pwgen.install.xml"
 	Invoke-WebRequest -Uri $releases -OutFile $File
 	$xml = Get-Content $File
-	$links=$xml | Where-Object {$_ -match 'Setup.exe/download'} | Where-Object {$_ -match 'link'}  | Select-Object -First 1
-	$url32 = $links.Split('<|>') | Where-Object {$_ -match 'download'}
+
+	# RSS is newest-first; grab the first Setup.exe entry
+	$links = $xml | Where-Object { $_ -match 'Setup\.exe/download' } | Where-Object { $_ -match 'link' } | Select-Object -First 1
+	$url32 = ($links.Split('<|>') | Where-Object { $_ -match '/download' })[0]
+
+	if (-not $url32) {
+		throw "Could not find Setup.exe download link in RSS feed"
+	}
+
 	$version = (Get-Version $url32).Version
 
-	$Latest = @{ URL32 = $url32; Version = $version }
+	# Use Get-FileVersion to compute checksum without bundling the installer; Get-FileVersion
+	# uses the second-to-last URL segment as filename, which is the real exe name, avoiding
+	# the /download suffix path error that -ChecksumFor 32 triggers.
+	$fileInfo = Get-FileVersion $url32
+	$checksum = $fileInfo.Checksum
+	$checksumType = $fileInfo.ChecksumType
+
+	$Latest = @{
+		URL32          = $url32
+		Version        = $version
+		Checksum32     = $checksum
+		ChecksumType32 = $checksumType
+	}
 	return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor none

--- a/automatic/pwgen.portable/update.ps1
+++ b/automatic/pwgen.portable/update.ps1
@@ -1,8 +1,9 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
+. ..\..\scripts\Get-FileVersion.ps1
 
-$releases = 'https://sourceforge.net/projects/pwgen-win/files/Password%20Tech/'
+$releases = 'https://sourceforge.net/projects/pwgen-win/rss?path=/Password%20Tech'
 
 function global:au_SearchReplace {
 	@{
@@ -22,11 +23,35 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$version = ((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_.href -match "Tech\/"} | Where-Object {$_.href -notmatch 'css'}).href[0].split('/')[-2]
-	$url = "https://sourceforge.net/projects/pwgen-win/files/Password%20Tech/$version/PwTech-$version-portable.zip/download"
+	$File = "$env:TEMP\pwgen.portable.xml"
+	Invoke-WebRequest -Uri $releases -OutFile $File
+	$xml = Get-Content $File
 
-	$Latest = @{ URL32 = $url; URL64 = $url; Version = $version }
+	# RSS is newest-first; grab the first portable.zip entry
+	$links = $xml | Where-Object { $_ -match 'portable\.zip/download' } | Where-Object { $_ -match 'link' } | Select-Object -First 1
+	$url = ($links.Split('<|>') | Where-Object { $_ -match '/download' })[0]
+
+	if (-not $url) {
+		throw "Could not find portable.zip download link in RSS feed"
+	}
+
+	$version = (Get-Version $url).Version
+
+	# Use Get-FileVersion to compute checksum without bundling the file in the package
+	$fileInfo = Get-FileVersion $url
+	$checksum = $fileInfo.Checksum
+	$checksumType = $fileInfo.ChecksumType
+
+	$Latest = @{
+		URL32          = $url
+		URL64          = $url
+		Version        = $version
+		Checksum32     = $checksum
+		ChecksumType32 = $checksumType
+		Checksum64     = $checksum
+		ChecksumType64 = $checksumType
+	}
 	return $Latest
 }
 
-update
+update -ChecksumFor none

--- a/automatic/tigervnc/update.ps1
+++ b/automatic/tigervnc/update.ps1
@@ -55,21 +55,32 @@ function global:au_GetLatest {
 		throw "Could not find both 32-bit and 64-bit download links"
 	}
 
-	$url32 = Get-RedirectedUrl $url32
-	$url64 = Get-RedirectedUrl $url64
-
-	. ..\..\scripts\Get-FileVersion.ps1
-	$FileVersion = Get-FileVersion $url32 -keep
+	# Do NOT call Get-RedirectedUrl here — it returns CDN mirror URLs with query params
+	# (?ts=...&use_mirror=...) that WebClient.DownloadFile treats as illegal path characters,
+	# breaking the AU retry loop and the VirusTotal scan (Get-RemoteFiles). Keep the permanent
+	# SourceForge /download URLs; Invoke-WebRequest follows the redirect automatically.
 
 	if (-not (Test-Path "tools")) {
 		New-Item -ItemType Directory -Path "tools" | Out-Null
 	}
 
+	. ..\..\scripts\Get-FileVersion.ps1
+	$FileVersion = Get-FileVersion $url32 -keep
 	Move-Item -Path $FileVersion.TempFile -Destination "tools\tigervnc.exe" -Force
 	$FileVersion64 = Get-FileVersion $url64 -keep
 	Move-Item -Path $FileVersion64.TempFile -Destination "tools\tigervnc64.exe" -Force
 
-	$Latest = @{ URL32 = $url32; URL64 = $url64; Version = $FileVersion.Version; Checksum32 = $FileVersion.Checksum; ChecksumType32 = $FileVersion.ChecksumType; Checksum64 = $FileVersion64.Checksum; ChecksumType64 = $FileVersion64.ChecksumType }
+	$Latest = @{
+		URL32          = $url32
+		URL64          = $url64
+		Version        = $FileVersion.Version
+		Checksum32     = $FileVersion.Checksum
+		ChecksumType32 = $FileVersion.ChecksumType
+		Checksum64     = $FileVersion64.Checksum
+		ChecksumType64 = $FileVersion64.ChecksumType
+		FileName32     = 'tigervnc.exe'
+		FileName64     = 'tigervnc64.exe'
+	}
 	return $Latest
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `Get-RedirectedUrl` resolved SourceForge `/download` URLs to CDN mirror URLs containing query params (`?ts=...&use_mirror=...`). `WebClient.DownloadFile` (used by AU retry loop and `Get-RemoteFiles` in `Invoke-VirusTotalScan`) interprets these query params as illegal file path characters, causing the error: _"Exception calling DownloadFile with 2 argument(s): Illegal characters in path"_.
- **Fix**: Removed `Get-RedirectedUrl` calls — keep the permanent SourceForge `/download` URLs in `$Latest`. `Invoke-WebRequest` inside `Get-FileVersion` follows redirects automatically without this problem.
- **VT scan fix**: Added `FileName32`/`FileName64` keys to `$Latest` so `Invoke-VirusTotalScan` identifies already-downloaded files and skips the `Get-RemoteFiles` call entirely.

## Test plan

- [ ] AU update run no longer fails with "Illegal characters in path" on tigervnc retry
- [ ] `$Latest.URL32` and `$Latest.URL64` contain stable SourceForge `/download` URLs (no CDN query params)
- [ ] `VERIFICATION.txt` is updated with permanent SourceForge URLs
- [ ] VirusTotal scan uses the bundled `tools/tigervnc.exe` / `tools/tigervnc64.exe` without re-downloading

Fixes CHO-435. Pattern consistent with CHO-433/CHO-434 (pwgen) and CHO-424 (dual-monitor-tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)