### PR TITLE
fix(winflector-client): use Get-FileVersion to avoid store URL redirect path error (CHO-437)

### DIFF
--- a/automatic/winflector-client/update.ps1
+++ b/automatic/winflector-client/update.ps1
@@ -1,5 +1,6 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
+. ..\..\scripts\Get-FileVersion.ps1
 
 $releases = "https://www.winflector.com/english/download.html"
 
@@ -21,15 +22,21 @@ function global:au_AfterUpdate($Package) {
 function global:au_GetLatest {
     $page = Invoke-WebRequest -Uri $releases -UseBasicParsing
     $link = ($page.Links | Where-Object {$_.outerHTML -match "Client for Windows"} | Select-Object -First 1)
-	$url32="https://www.winflector.com/$($link.href)"
+    $url32 = "https://www.winflector.com/$($link.href)"
 
     $regexPattern = 'Client for Windows \((\d+(\.\d+)*)'
-	$versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
-	$version = $versionMatch.Matches[0].Groups[1].Value
+    $versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
+    $version = $versionMatch.Matches[0].Groups[1].Value
 
-	$Latest = @{ URL32 = $url32; Version = $version }
+    $FileVersion = Get-FileVersion $url32
+    $Latest = @{
+        URL32         = $url32
+        Version       = $version
+        Checksum32    = $FileVersion.Checksum
+        ChecksumType32 = $FileVersion.ChecksumType
+    }
 
     return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor none


### PR DESCRIPTION
## Summary

- The store URL `https://www.winflector.com/store/free-version/index/id/567` redirects to the `567.com` domain
- AU's `ChecksumFor 32` follows the redirect and tries to use the final URL as a Windows file path, producing `tools/567.com/store/free-version/index/id/567` — which triggers "Illegal characters in path"
- Fix: import `Get-FileVersion.ps1` and compute the checksum inside `au_GetLatest`, then use `update -ChecksumFor none` to bypass AU's redirect-prone checksum logic

## Test plan

- [ ] Run `.\update.ps1` in `automatic/winflector-client/` — should complete without "Illegal characters in path" error
- [ ] Verify `Checksum32` and `ChecksumType32` are populated in `$Latest`
- [ ] Confirm `tools/chocolateyInstall.ps1` is updated with the correct URL and checksum

Fixes CHO-437

🤖 Generated with [Claude Code](https://claude.ai/claude-code)