### PR TITLE
fix(projectlibre.install): keep permanent SourceForge URL to fix illegal path characters (CHO-436)

### DIFF
--- a/automatic/projectlibre.install/update.ps1
+++ b/automatic/projectlibre.install/update.ps1
@@ -1,5 +1,6 @@
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
+. ..\..\scripts\Get-FileVersion.ps1
 
 function global:au_SearchReplace {
 	@{
@@ -30,14 +31,20 @@ function global:au_GetLatest {
 	}
 	$version = $versionMatch.Matches[0].Groups[1].Value
 
-	# Version 1.9.x distributes MSI for Windows (no EXE available)
-	$url32 = Get-RedirectedUrl "https://sourceforge.net/projects/projectlibre/files/ProjectLibre/$version/ProjectLibre-$version.msi/download"
-	if (-not $url32) {
-		throw "Could not get MSI download URL for version $version"
-	}
+	# Keep the permanent SourceForge /download URL — do NOT call Get-RedirectedUrl here.
+	# Get-RedirectedUrl returns CDN mirror URLs with query params (?ts=...&use_mirror=...)
+	# that WebClient.DownloadFile treats as illegal path characters, breaking AU's checksum
+	# logic. Invoke-WebRequest (used by Get-FileVersion) follows the redirect transparently.
+	$url32 = "https://sourceforge.net/projects/projectlibre/files/ProjectLibre/$version/ProjectLibre-$version.msi/download"
 
-	$Latest = @{ URL32 = $url32; Version = $version }
+	$FileVersion = Get-FileVersion $url32
+	$Latest = @{
+		URL32          = $url32
+		Version        = $version
+		Checksum32     = $FileVersion.Checksum
+		ChecksumType32 = $FileVersion.ChecksumType
+	}
 	return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor none


### PR DESCRIPTION
## Summary

- `Get-RedirectedUrl` was called on the MSI SourceForge URL, which returned a CDN mirror URL with query params like `?ts=...&use_mirror=auto`
- `.NET WebClient.DownloadFile()` (used internally by AU's `ChecksumFor 32`) treats query params as part of the local file path, producing illegal Windows path characters (`?`, `=`, `&`)
- This caused the AU retry loop to fail with *"Exception calling DownloadFile with 2 argument(s): Illegal characters in path"*

**Fix:** Keep the permanent SourceForge `/download` URL in `$Latest` (no query params = no illegal chars); use `Get-FileVersion` (which uses `Invoke-WebRequest` and handles redirects transparently) to download the MSI and compute the checksum; switch to `update -ChecksumFor none`.

Same pattern as CHO-435 (tigervnc) and CHO-437 (winflector-client).

## Test plan

- [ ] AU update runs without "Illegal characters in path" error for `projectlibre.install`
- [ ] `$url32` in `chocolateyInstall.ps1` remains the clean permanent SourceForge URL
- [ ] Checksum fields (`$checksum`, `$checksumType`) are correctly updated by `Get-FileVersion`