### PR TITLE
fix(bonjour): replace em-dash on lines 26 and 49 to fix AppVeyor parse error (CHO-442)

### DIFF
--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -23,7 +23,7 @@ function global:au_BeforeUpdate($Package) {
 	if (Test-Path $exeFile) {
 		$Latest.Checksum32 = (Get-FileHash -Path $exeFile -Algorithm $Latest.ChecksumType32).Hash.ToLower()
 	} else {
-		throw "iTunes installer not found at '$exeFile' — download may have failed."
+		throw "iTunes installer not found at '$exeFile' - download may have failed."
 	}
 	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType64 -Url $Latest.URL64
 }
@@ -46,7 +46,7 @@ function global:au_GetLatest {
 	if (Test-Path $bonjourMsi) {
 		7z.exe x $bonjourMsi -i!"mDNSResponder.exe" -y | Out-Null
 	} else {
-		Write-Warning "Bonjour.msi not found inside the iTunes installer — Apple may have changed the installer format."
+		Write-Warning "Bonjour.msi not found inside the iTunes installer - Apple may have changed the installer format."
 	}
 
 	Write-Output 'Get version'


### PR DESCRIPTION
## Problem

`automatic/bonjour/update.ps1` contains UTF-8 em-dash characters (U+2014) on two lines. AppVeyor PowerShell reads the file as Windows-1252, interpreting `\xe2\x80\x94` as `â€"`, which breaks string literals and causes a parse error.

Previous fix CHO-422 replaced line 26 only. Line 49 (`Write-Warning`) still had the em-dash and continued to fail.

## Fix

- Line 26: `throw "... '$exeFile' — download ..."` → ASCII hyphen
- Line 49: `Write-Warning "... installer — Apple ..."` → ASCII hyphen

## Supersedes

This PR supersedes [#4029](https://github.com/tunisiano187/Chocolatey-packages/pull/4029) which only fixed line 26. PR #4029 can be closed.

## Test

No functional change — only string literal encoding. AppVeyor will no longer fail with unexpected token error on either line.

Closes #CHO-442