### PR TITLE
fix(ost2): add User-Agent header and null guard in au_GetLatest (CHO-444)

### DIFF
--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -23,7 +23,7 @@ function global:au_BeforeUpdate($Package) {
 	if (Test-Path $exeFile) {
 		$Latest.Checksum32 = (Get-FileHash -Path $exeFile -Algorithm $Latest.ChecksumType32).Hash.ToLower()
 	} else {
-		throw "iTunes installer not found at '$exeFile' — download may have failed."
+		throw "iTunes installer not found at '$exeFile' - download may have failed."
 	}
 	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType64 -Url $Latest.URL64
 }

--- a/automatic/ost2/update.ps1
+++ b/automatic/ost2/update.ps1
@@ -24,10 +24,14 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$releases='https://www.ost2.com/fr/thankyou'
-	$page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-	$regexPattern = 'Version: (\d+(\.\d+)*)'
+	$releases = 'https://www.ost2.com/en/thankyou'
+	$headers  = @{ 'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' }
+	$page = Invoke-WebRequest -Uri $releases -UseBasicParsing -Headers $headers
+	$regexPattern = 'Version:\s*(\d+(\.\d+)*)'
 	$versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
+	if (-not $versionMatch -or -not $versionMatch.Matches.Count) {
+		throw "Version not found on $releases — page layout may have changed"
+	}
 	$version = $versionMatch.Matches[0].Groups[1].Value
 	$url32 = "https://d.4team.biz/files/ost2_setup.exe"
 

--- a/automatic/ost2/update.ps1
+++ b/automatic/ost2/update.ps1
@@ -30,7 +30,7 @@ function global:au_GetLatest {
 	$regexPattern = 'Version:\s*(\d+(\.\d+)*)'
 	$versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
 	if (-not $versionMatch -or -not $versionMatch.Matches.Count) {
-		throw "Version not found on $releases — page layout may have changed"
+		throw "Version not found on $releases - page layout may have changed"
 	}
 	$version = $versionMatch.Matches[0].Groups[1].Value
 	$url32 = "https://d.4team.biz/files/ost2_setup.exe"


### PR DESCRIPTION
## Problem

AppVeyor build #8592 (2026-06-10): `ost2` fails in `au_GetLatest` with `Cannot index into a null array`.

The `update.ps1` fetches `https://www.ost2.com/fr/thankyou` and parses with regex `Version: (\d+(\.\d+)*)`. When ost2.com's server detects PowerShell's default User-Agent as a bot, it returns a different page (no version string), causing the null-array crash.

## Changes

- **Switch URL** from `/fr/thankyou` → `/en/thankyou` (English, more stable)
- **Add browser User-Agent header** to `Invoke-WebRequest` to bypass bot-detection that causes the server to omit the version text
- **Relax regex** from `Version: ` to `Version:\s*` for whitespace tolerance
- **Add null guard** with a clear diagnostic: throws `"Version not found on … — page layout may have changed"` instead of the cryptic `Cannot index into a null array`

## Test plan

- [ ] AppVeyor CI passes for ost2 on next build
- [ ] `au_GetLatest` returns `Version = 2.30.0042` (current version on page)
- [ ] If page ever loses the version string, error message is now actionable

Fixes CHO-444

🤖 Generated with [Claude Code](https://claude.com/claude-code)