### PR TITLE
fix(bonjour,brave-nightly): replace remaining em-dashes with ASCII hyphens (CHO-451)

### DIFF
--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -23,7 +23,7 @@ function global:au_BeforeUpdate($Package) {
 	if (Test-Path $exeFile) {
 		$Latest.Checksum32 = (Get-FileHash -Path $exeFile -Algorithm $Latest.ChecksumType32).Hash.ToLower()
 	} else {
-		throw "iTunes installer not found at '$exeFile' — download may have failed."
+		throw "iTunes installer not found at '$exeFile' - download may have failed."
 	}
 	$Latest.Checksum64 = Get-RemoteChecksum -Algorithm $Latest.ChecksumType64 -Url $Latest.URL64
 }
@@ -46,7 +46,7 @@ function global:au_GetLatest {
 	if (Test-Path $bonjourMsi) {
 		7z.exe x $bonjourMsi -i!"mDNSResponder.exe" -y | Out-Null
 	} else {
-		Write-Warning "Bonjour.msi not found inside the iTunes installer — Apple may have changed the installer format."
+		Write-Warning "Bonjour.msi not found inside the iTunes installer - Apple may have changed the installer format."
 	}
 
 	Write-Output 'Get version'

--- a/automatic/brave-nightly/update.ps1
+++ b/automatic/brave-nightly/update.ps1
@@ -24,7 +24,7 @@ function global:au_GetLatest {
 
 	# Use the GitHub API to get recent releases and find the latest prerelease (nightly).
 	# The old approach scraped the HTML tags page and took the first tag, which could be a
-	# stable release — leaving $url32 null and causing AU "URL check" failures.
+	# stable release - leaving $url32 null and causing AU "URL check" failures.
 	$headers = @{ 'User-Agent' = 'chocolatey-au-updater/1.0' }
 	$releases = Invoke-RestMethod "https://api.github.com/repos/$Owner/$repo/releases?per_page=20" -Headers $headers
 


### PR DESCRIPTION
## Summary

Fixes em-dash (U+2014) characters in two `update.ps1` files that remain on master after CHO-450 only partially addressed the bonjour issue.

### Changes

**bonjour/update.ps1** — two em-dashes on lines 26 and 49:
- Line 26: `throw "iTunes installer not found at '$exeFile' — download may have failed."` → `- download may have failed.`
- Line 49: `Write-Warning "Bonjour.msi not found inside the iTunes installer — Apple may have changed the installer format."` → `- Apple may have changed the installer format.`

**brave-nightly/update.ps1** — em-dash in comment on line 27:
- `# stable release — leaving $url32 null` → `# stable release - leaving $url32 null`

### Root cause

Em-dash (U+2014) in PowerShell string literals and comments causes `Exception calling "GetVersionInfo"` or parse errors on Windows CI runners when the file is read using Windows-1252 encoding. CHO-450 fixed only the first bonjour occurrence (line 26); lines 49 and the brave-nightly comment were missed.

### Related

- Closes the remaining em-dash issues identified during CHO-451 daily analysis
- Supersedes PR #4052 (fix/bonjour-em-dash-both-lines-cho442) — that PR has been in an unmerged state since line 26 was directly committed via CHO-450; this PR is a clean, targeted replacement
- PR #4053 (ost2) was updated separately to fix an em-dash introduced in its throw message