### PR TITLE
fix(projectlibre.portable): use Get-FileVersion to avoid SourceForge CDN path error (CHO-453)

### DIFF
--- a/automatic/projectlibre.portable/update.ps1
+++ b/automatic/projectlibre.portable/update.ps1
@@ -1,12 +1,12 @@
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
-
+. ..\..\scripts\Get-FileVersion.ps1
 
 function global:au_SearchReplace {
 	@{
 		'tools/chocolateyInstall.ps1' = @{
-			"(^[$]url\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
-			"(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+			"(^[$]url\s*=\s*)('.*')"          = "`$1'$($Latest.URL32)'"
+			"(^[$]checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
 			"(^[$]checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
 		}
 	}
@@ -18,8 +18,8 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	# SourceForge latest/download redirects to the jar file URL which contains the version
-	$redirectUrl = Get-RedirectedUrl 'http://sourceforge.net/projects/projectlibre/files/latest/download'
+	# SourceForge latest/download redirects to the JAR file URL which contains the version
+	$redirectUrl = Get-RedirectedUrl 'https://sourceforge.net/projects/projectlibre/files/latest/download'
 	if (-not $redirectUrl) {
 		throw "Could not follow SourceForge redirect"
 	}
@@ -31,14 +31,20 @@ function global:au_GetLatest {
 	}
 	$version = $versionMatch.Matches[0].Groups[1].Value
 
-	# Construct direct ZIP download URL (lowercase filename)
-	$url32 = Get-RedirectedUrl "https://sourceforge.net/projects/projectlibre/files/ProjectLibre/$version/projectlibre-$version.zip/download"
-	if (-not $url32) {
-		throw "Could not get ZIP download URL for version $version"
-	}
+	# Keep the permanent SourceForge /download URL — do NOT call Get-RedirectedUrl here.
+	# Get-RedirectedUrl returns CDN mirror URLs with query params (?viasf=1, ?ts=...&use_mirror=...)
+	# that WebClient.DownloadFile treats as illegal path characters, breaking AU's checksum
+	# logic. Get-FileVersion uses Invoke-WebRequest which follows the redirect transparently.
+	$url32 = "https://sourceforge.net/projects/projectlibre/files/ProjectLibre/$version/projectlibre-$version.zip/download"
 
-	$Latest = @{ URL32 = $url32; Version = $version }
+	$FileVersion = Get-FileVersion $url32
+	$Latest = @{
+		URL32          = $url32
+		Version        = $version
+		Checksum32     = $FileVersion.Checksum
+		ChecksumType32 = $FileVersion.ChecksumType
+	}
 	return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor none


### PR DESCRIPTION
## Problem

`Get-RedirectedUrl` on the SourceForge ZIP download URL returns a CDN mirror URL with query parameters (e.g. `?viasf=1`, `?ts=...&use_mirror=...`).

`WebClient.DownloadFile()` (used internally by AU's `ChecksumFor 32`) treats query params as part of the local file path, producing **illegal Windows path characters** (`?`, `=`, `&`), which causes:

```
Exception calling "DownloadFile" with "2" argument(s): Illegal characters in path.
```

This is the same root cause fixed for `projectlibre.install` in PR #4051 / [CHO-436](https://github.com/tunisiano187/Chocolatey-packages/issues/CHO-436).

## Fix

- Store the permanent SourceForge `/download` URL in `$url32` — do **not** call `Get-RedirectedUrl` on it
- Use `Get-FileVersion` (which uses `Invoke-WebRequest` internally) to compute the checksum by following the redirect transparently
- Switch to `update -ChecksumFor none` since checksums are now computed inline in `au_GetLatest`
- Upgrade the version-discovery redirect from `http://` to `https://`

## Testing

The fix mirrors the approach in PR #4051 (`projectlibre.install`) which has all CI checks passing.

Detected during daily package analysis ([CHO-453](/CHO/issues/CHO-453)).