### PR TITLE
fix(windjview): use Get-FileVersion to avoid SourceForge /download path error (CHO-461)

### DIFF
--- a/automatic/windjview/update.ps1
+++ b/automatic/windjview/update.ps1
@@ -1,4 +1,5 @@
 import-module chocolatey-AU
+. ..\..\scripts\Get-FileVersion.ps1
 
 # Use the SourceForge RSS feed scoped to /WinDjView so any future version folder
 # (e.g. 2.2, 3.0) is discovered automatically instead of being hardcoded.
@@ -31,19 +32,27 @@ function global:au_GetLatest {
 	$version = [regex]::Match($url32, 'WinDjView-(\d+(?:\.\d+)+)-Setup\.exe').Groups[1].Value
 	if (-not $version) { throw "Could not parse version from URL: $url32" }
 
+	# Use Get-FileVersion (Invoke-WebRequest) to follow the SourceForge /download
+	# redirect and compute the checksum. WebClient.DownloadFile (used by both
+	# Get-RemoteChecksum and AU's -ChecksumFor) treats the trailing /download path
+	# segment as a nested directory, causing a DirectoryNotFoundException.
+	$fileVersion = Get-FileVersion $url32
+
 	# Detect silent binary replacements: if the remote checksum differs from the
 	# value already stored in chocolateyInstall.ps1, bump with a datestamp so AU
 	# publishes the corrected binary even when the upstream version string is unchanged.
 	$installContent   = Get-Content "$PSScriptRoot\tools\chocolateyInstall.ps1" -Raw
 	$current_checksum = [regex]::Match($installContent, "\`$checksum\s*=\s*'([a-fA-F0-9]{64})'").Groups[1].Value
-	if ($current_checksum.Length -eq 64) {
-		$remote_checksum = Get-RemoteChecksum $url32
-		if ($current_checksum -ne $remote_checksum) {
-			$version = "$version.$(Get-Date -Format 'yyyyMMdd')"
-		}
+	if ($current_checksum.Length -eq 64 -and $current_checksum -ne $fileVersion.Checksum) {
+		$version = "$version.$(Get-Date -Format 'yyyyMMdd')"
 	}
 
-	return @{ URL32 = $url32; Version = $version }
+	return @{
+		URL32          = $url32
+		Version        = $version
+		Checksum32     = $fileVersion.Checksum
+		ChecksumType32 = $fileVersion.ChecksumType
+	}
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

- **Root cause**: SourceForge `/download` URLs end with the path segment `download`, causing `WebClient.DownloadFile` (used by both AU's `-ChecksumFor 32` and `Get-RemoteChecksum`) to try to write the file as `tools\download.exe\download` — treating `download.exe` as a directory that doesn't exist → `DirectoryNotFoundException`
- **Fix**: Import `Get-FileVersion.ps1` and call `Get-FileVersion` (which uses `Invoke-WebRequest` and follows redirects correctly) to compute the checksum in `au_GetLatest`, then switch to `-ChecksumFor none`
- This is the same pattern applied in CHO-460 for `projectlibre.install`

## Changes

- `automatic/windjview/update.ps1`: add `. ..\..\scripts\Get-FileVersion.ps1`, replace `Get-RemoteChecksum` with `Get-FileVersion`, return `Checksum32`/`ChecksumType32` in `$Latest`, change `update -ChecksumFor 32` → `update -ChecksumFor none`

## Test plan

- [ ] AU runs `au_GetLatest` → RSS feed returns SourceForge `/download` URL
- [ ] `Get-FileVersion` follows the redirect via `Invoke-WebRequest` → computes SHA256 checksum without path errors
- [ ] `$Latest` includes `Checksum32` and `ChecksumType32`
- [ ] `update -ChecksumFor none` completes without `DirectoryNotFoundException`
- [ ] `chocolateyInstall.ps1` gets updated checksum value via `au_SearchReplace`

Closes #CHO-461

🤖 Generated with [Claude Code](https://claude.ai/claude-code)