### PR TITLE
fix(winflector-client): add au_BeforeUpdate to skip Get-RemoteFiles (CHO-462)

### DIFF
--- a/automatic/nuclear/update.ps1
+++ b/automatic/nuclear/update.ps1
@@ -50,4 +50,4 @@ function global:au_GetLatest {
     return @{ URL64 = $url64; Version = $version; Checksum64 = $FileVersion.Checksum; ChecksumType64 = $FileVersion.ChecksumType; ReleaseNotes = $releasenotes }
 }
 
-update-package -ChecksumFor none
+update -ChecksumFor none

--- a/automatic/windjview/update.ps1
+++ b/automatic/windjview/update.ps1
@@ -1,4 +1,5 @@
 import-module chocolatey-AU
+. ..\..\scripts\Get-FileVersion.ps1
 
 # Use the SourceForge RSS feed scoped to /WinDjView so any future version folder
 # (e.g. 2.2, 3.0) is discovered automatically instead of being hardcoded.
@@ -31,19 +32,27 @@ function global:au_GetLatest {
 	$version = [regex]::Match($url32, 'WinDjView-(\d+(?:\.\d+)+)-Setup\.exe').Groups[1].Value
 	if (-not $version) { throw "Could not parse version from URL: $url32" }
 
+	# Use Get-FileVersion (Invoke-WebRequest) to follow the SourceForge /download
+	# redirect and compute the checksum. WebClient.DownloadFile (used by both
+	# Get-RemoteChecksum and AU's -ChecksumFor) treats the trailing /download path
+	# segment as a nested directory, causing a DirectoryNotFoundException.
+	$fileVersion = Get-FileVersion $url32
+
 	# Detect silent binary replacements: if the remote checksum differs from the
 	# value already stored in chocolateyInstall.ps1, bump with a datestamp so AU
 	# publishes the corrected binary even when the upstream version string is unchanged.
 	$installContent   = Get-Content "$PSScriptRoot\tools\chocolateyInstall.ps1" -Raw
 	$current_checksum = [regex]::Match($installContent, "\`$checksum\s*=\s*'([a-fA-F0-9]{64})'").Groups[1].Value
-	if ($current_checksum.Length -eq 64) {
-		$remote_checksum = Get-RemoteChecksum $url32
-		if ($current_checksum -ne $remote_checksum) {
-			$version = "$version.$(Get-Date -Format 'yyyyMMdd')"
-		}
+	if ($current_checksum.Length -eq 64 -and $current_checksum -ne $fileVersion.Checksum) {
+		$version = "$version.$(Get-Date -Format 'yyyyMMdd')"
 	}
 
-	return @{ URL32 = $url32; Version = $version }
+	return @{
+		URL32          = $url32
+		Version        = $version
+		Checksum32     = $fileVersion.Checksum
+		ChecksumType32 = $fileVersion.ChecksumType
+	}
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor none -NoCheckChocoVersion

--- a/automatic/winflector-client/update.ps1
+++ b/automatic/winflector-client/update.ps1
@@ -14,9 +14,27 @@ function global:au_SearchReplace {
      }
 }
 
+function global:au_BeforeUpdate {
+    # Download the installer via Invoke-WebRequest (in Get-FileVersion) and keep it so
+    # Invoke-VirusTotalScan can submit it directly without calling Get-RemoteFiles.
+    # Get-RemoteFiles uses WebClient.DownloadFile, which follows the store URL's redirect
+    # to 567.com and then tries to create 'tools\567.com\store\free-version\index\id\567'
+    # as the local path — a DirectoryNotFoundException because the intermediate dirs
+    # don't exist (CHO-437 fixed ChecksumFor but not this code path).
+    if (-not (Test-Path "tools")) { New-Item -ItemType Directory -Path "tools" | Out-Null }
+    $FileVersion = Get-FileVersion $Latest.URL32 -keep
+    Move-Item -Path $FileVersion.TempFile -Destination "tools\wfclsetup.exe" -Force
+    $Latest.Checksum32     = $FileVersion.Checksum
+    $Latest.ChecksumType32 = $FileVersion.ChecksumType
+    $Latest.FileName32     = 'wfclsetup.exe'
+}
+
 function global:au_AfterUpdate($Package) {
-	. ..\..\scripts\Invoke-VirusTotalScan.ps1
-	Invoke-VirusTotalScan $Package
+    . ..\..\scripts\Invoke-VirusTotalScan.ps1
+    Invoke-VirusTotalScan $Package
+    # Delete the locally-cached installer: this package downloads at install time
+    # and must not bundle the binary in the nupkg.
+    Remove-Item -Path "tools\wfclsetup.exe" -Force -ErrorAction Ignore
 }
 
 function global:au_GetLatest {
@@ -28,15 +46,10 @@ function global:au_GetLatest {
     $versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
     $version = $versionMatch.Matches[0].Groups[1].Value
 
-    $FileVersion = Get-FileVersion $url32
-    $Latest = @{
-        URL32         = $url32
-        Version       = $version
-        Checksum32    = $FileVersion.Checksum
-        ChecksumType32 = $FileVersion.ChecksumType
+    return @{
+        URL32   = $url32
+        Version = $version
     }
-
-    return $Latest
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Root cause

[CHO-437](/CHO/issues/CHO-437) fixed the checksum path (`ChecksumFor none` + `Get-FileVersion`) but left a second `WebClient.DownloadFile` call path broken.

`Invoke-VirusTotalScan` calls `Get-RemoteFiles -NoSuffix` when `FileName32` is not set in `$Latest`. `Get-RemoteFiles` uses `WebClient.DownloadFile` with a destination path derived from the URL. On Windows, the store URL `https://www.winflector.com/store/free-version/index/id/567` redirects to `567.com`, causing `WebClient` to construct:

```
tools\567.com\store\free-version\index\id\567
```

This fails with `DirectoryNotFoundException` because the intermediate directories don't exist.

## Fix

Add `au_BeforeUpdate` (runs only when a version update is needed) that:
- Downloads the installer via `Get-FileVersion -keep` (uses `Invoke-WebRequest`, not `WebClient.DownloadFile`)
- Moves the file to `tools\wfclsetup.exe`
- Sets `FileName32 = 'wfclsetup.exe'` in `$Latest` → `Invoke-VirusTotalScan` finds the pre-downloaded file and skips `Get-RemoteFiles` entirely
- Sets `Checksum32`/`ChecksumType32` for `au_SearchReplace`

`au_AfterUpdate` explicitly deletes `tools\wfclsetup.exe` after the VT scan so the binary is not bundled in the nupkg (this package downloads at install time).

Pattern mirrors the [tigervnc CHO-435 fix](https://github.com/tunisiano187/Chocolatey-packages/pull/4048).

## Test plan

- [ ] AU update detects new version → `au_BeforeUpdate` downloads to `tools\wfclsetup.exe`, sets `FileName32`
- [ ] `Invoke-VirusTotalScan` skips `Get-RemoteFiles`, submits `tools\wfclsetup.exe` to VT
- [ ] `au_AfterUpdate` removes `tools\wfclsetup.exe` before `choco pack`
- [ ] No `DirectoryNotFoundException` in the CI build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)