### PR TITLE
fix(bonjour): replace em dash with hyphen to fix CP1252 parse error (CHO-471)

### DIFF
--- a/automatic/bonjour/update.ps1
+++ b/automatic/bonjour/update.ps1
@@ -46,7 +46,7 @@ function global:au_GetLatest {
 	if (Test-Path $bonjourMsi) {
 		7z.exe x $bonjourMsi -i!"mDNSResponder.exe" -y | Out-Null
 	} else {
-		Write-Warning "Bonjour.msi not found inside the iTunes installer — Apple may have changed the installer format."
+		Write-Warning "Bonjour.msi not found inside the iTunes installer - Apple may have changed the installer format."
 	}
 
 	Write-Output 'Get version'


### PR DESCRIPTION
## Root cause

`automatic/bonjour/update.ps1` contains an em dash (U+2014, UTF-8 bytes `e2 80 94`) in a `Write-Warning` string on line 49. On Windows, PowerShell 5.x reads UTF-8-without-BOM files as CP1252 by default. In CP1252, byte `0x94` maps to U+201D (RIGHT DOUBLE QUOTATION MARK `"`), which PowerShell recognises as a string terminator. This prematurely closes the string literal, producing the cascading parse errors seen in AU runs since commit `a4214bda4`:

```
At C:\projects\chocolatey-packages\automatic\bonjour\update.ps1:64 char:22
+         $version = "3.1.0.5"
+                            ~
The string is missing the terminator: ".
```

This is the same root cause as CHO-442 and CHO-450. Those fixes addressed line 26 but line 49 (`Write-Warning "... — Apple may have changed..."`) retained the em dash and was missed.

## Fix

Replace the remaining em dash on line 49 with an ASCII hyphen (` - `). No logic changes.

## Test plan

- [ ] AU runs `bonjour/update.ps1` without parse errors on the next CI cycle
- [ ] Fallback version `3.1.0.5` is returned cleanly
- [ ] No `The string is missing the terminator` error in the AU report

🤖 Generated with [Claude Code](https://claude.ai/claude-code)