### PR TITLE
fix(nteract.install): replace deprecated update-package with update (CHO-466)

### DIFF
--- a/automatic/nteract.install/update.ps1
+++ b/automatic/nteract.install/update.ps1
@@ -43,4 +43,4 @@ function global:au_GetLatest {
     return @{ URL32 = $url32; Version = $version }
 }
 
-update-package -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32 -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

- Replaces the deprecated `update-package` AU alias with `update` in `automatic/nteract.install/update.ps1`
- All other packages in this repo already use `update`; nteract.install was using the deprecated alias

## Investigation findings (CHO-466)

The `nteract.install` package is at v0.28.0 on chocolatey.org while the repo has v2.5.1. Versions 1.x and 2.x have never been published, indicating a repeated push failure.

Root cause analysis:
- `update-package` is a deprecated alias for `update` in chocolatey-AU
- This same pattern was identified and fixed for `nuclear` in PR #4066
- Using the canonical `update` command ensures consistent behaviour with the rest of the repository

The `nteract` meta-package is also stuck because its `update.ps1` reads the version via `choco search nteract.install` from chocolatey.org — once `nteract.install` is correctly published at v2.5.1, the meta-package will update on the next AU run.

## Test plan

- [ ] CI passes on this PR
- [ ] Next AU run for nteract.install should show `Pushed: True` and v2.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)