### PR TITLE
fix(pwgen.install): replace brittle line-split XML parsing with [xml] cast

### DIFF
--- a/automatic/pwgen.install/update.ps1
+++ b/automatic/pwgen.install/update.ps1
@@ -20,34 +20,18 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$File = "$env:TEMP\pwgen.install.xml"
-	Invoke-WebRequest -Uri $releases -OutFile $File
-	$xml = Get-Content $File
+	[xml]$xml = (Invoke-WebRequest -Uri $releases -UseBasicParsing).Content
+	$item = $xml.rss.channel.item | Where-Object { $_.link -match '(?i)Setup\.exe/download' -and $_.link -notmatch '\.sig/' } | Select-Object -First 1
+	$url32 = $item.link
+	$version = [regex]::Match($url32, 'Password%20Tech/([^/]+)/').Groups[1].Value
 
-	# RSS is newest-first; grab the first Setup.exe entry
-	$links = $xml | Where-Object { $_ -match 'Setup\.exe/download' } | Where-Object { $_ -match 'link' } | Select-Object -First 1
-	$url32 = ($links.Split('<|>') | Where-Object { $_ -match '/download' })[0]
-
-	if (-not $url32) {
-		throw "Could not find Setup.exe download link in RSS feed"
-	}
-
-	$version = (Get-Version $url32).Version
-
-	# Use Get-FileVersion to compute checksum without bundling the installer; Get-FileVersion
-	# uses the second-to-last URL segment as filename, which is the real exe name, avoiding
-	# the /download suffix path error that -ChecksumFor 32 triggers.
 	$fileInfo = Get-FileVersion $url32
-	$checksum = $fileInfo.Checksum
-	$checksumType = $fileInfo.ChecksumType
-
-	$Latest = @{
+	@{
 		URL32          = $url32
 		Version        = $version
-		Checksum32     = $checksum
-		ChecksumType32 = $checksumType
+		Checksum32     = $fileInfo.Checksum
+		ChecksumType32 = $fileInfo.ChecksumType
 	}
-	return $Latest
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Problem

`au_GetLatest` was splitting the RSS response line-by-line and using `String.Split('<|>')` to extract the download URL. PowerShell's `Split` overload with a multi-character string argument returns the input unchanged, so `Get-Version` received a garbled full line and extracted `h` (first char of `https://`) as the version.

This caused AU to report: `Invalid version: h.`

## Fix

Replace the line-by-line text parsing with:
- `[xml]` cast for robust XML navigation
- `.rss.channel.item | Where-Object { $_.link -match '...' }` to find the Setup.exe entry
- `[regex]::Match($url32, 'Password%20Tech/([^/]+)/').Groups[1].Value` to extract the version

The `Get-FileVersion` checksum logic is preserved from master.

## Scope

This PR is scoped to `automatic/pwgen.install/update.ps1` only.

Companion PR for `pwgen.portable` is separate per project policy.

Fixes CHO-459