### PR TITLE
fix(pwgen.portable): replace brittle line-split XML parsing with [xml] cast

### DIFF
--- a/automatic/pwgen.portable/update.ps1
+++ b/automatic/pwgen.portable/update.ps1
@@ -23,35 +23,21 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$File = "$env:TEMP\pwgen.portable.xml"
-	Invoke-WebRequest -Uri $releases -OutFile $File
-	$xml = Get-Content $File
+	[xml]$xml = (Invoke-WebRequest -Uri $releases -UseBasicParsing).Content
+	$item = $xml.rss.channel.item | Where-Object { $_.link -match 'portable\.zip/download' } | Select-Object -First 1
+	$url = $item.link
+	$version = [regex]::Match($url, 'Password%20Tech/([^/]+)/').Groups[1].Value
 
-	# RSS is newest-first; grab the first portable.zip entry
-	$links = $xml | Where-Object { $_ -match 'portable\.zip/download' } | Where-Object { $_ -match 'link' } | Select-Object -First 1
-	$url = ($links.Split('<|>') | Where-Object { $_ -match '/download' })[0]
-
-	if (-not $url) {
-		throw "Could not find portable.zip download link in RSS feed"
-	}
-
-	$version = (Get-Version $url).Version
-
-	# Use Get-FileVersion to compute checksum without bundling the file in the package
 	$fileInfo = Get-FileVersion $url
-	$checksum = $fileInfo.Checksum
-	$checksumType = $fileInfo.ChecksumType
-
-	$Latest = @{
+	@{
 		URL32          = $url
 		URL64          = $url
 		Version        = $version
-		Checksum32     = $checksum
-		ChecksumType32 = $checksumType
-		Checksum64     = $checksum
-		ChecksumType64 = $checksumType
+		Checksum32     = $fileInfo.Checksum
+		ChecksumType32 = $fileInfo.ChecksumType
+		Checksum64     = $fileInfo.Checksum
+		ChecksumType64 = $fileInfo.ChecksumType
 	}
-	return $Latest
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Problem

`au_GetLatest` was splitting the RSS response line-by-line and using `String.Split('<|>')` to extract the download URL. PowerShell's `Split` overload with a multi-character string argument returns the input unchanged, so `Get-Version` received a garbled full line and extracted `h` (first char of `https://`) as the version.

This caused AU to report: `Invalid version: h.`

## Fix

Replace the line-by-line text parsing with:
- `[xml]` cast for robust XML navigation
- `.rss.channel.item | Where-Object { $_.link -match 'portable\.zip/download' }` to find the right entry
- `[regex]::Match($url, 'Password%20Tech/([^/]+)/').Groups[1].Value` to extract the version

The `Get-FileVersion` checksum logic is preserved from master.

## Scope

This PR is scoped to `automatic/pwgen.portable/update.ps1` only.

Companion PR for `pwgen.install` is #4072 per project policy (one package per PR).

Fixes CHO-459