### PR TITLE
fix(captureflux): use specific URL match to avoid fragile zip$-first selection

### DIFF
--- a/automatic/captureflux/update.ps1
+++ b/automatic/captureflux/update.ps1
@@ -27,11 +27,17 @@ function global:au_AfterUpdate($Package) {
 
 function global:au_GetLatest {
 	$page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-	$url32 = "https://paulglagla.com/$($page.Links.href | Where-Object {$_ -match "zip$"} | Select-Object -First 1)"
+
+	# Prefer the absolute paulglagla.com link if present on the page; fall back to constructing from relative link
+	$url32 = $page.Links.href | Where-Object { $_ -match 'https://paulglagla\.com.*captureflux.*\.zip$' } | Select-Object -First 1
+	if (-not $url32) {
+		$relLink = $page.Links.href | Where-Object { $_ -match 'captureflux.*\.zip$' } | Select-Object -First 1
+		$url32 = "https://paulglagla.com/$relLink"
+	}
+
 	$regexPattern = '(\d+(\.\d+)*)</b>'
 	$versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
 	$version = $versionMatch.Matches[0].Groups[1].Value
-
 
 	$Latest = @{ URL32 = $url32; Version = $version; Checksum32 = ''; ChecksumType32 = 'sha256' }
 	return $Latest


### PR DESCRIPTION
## Problem

The AU run of 2026-06-17 08:19 UTC failed with:

```
Can't validate URL
Exception calling "GetResponse" with "0" argument(s): "Unable to connect to the remote server":
https://paulglagla.com/fichiers/captureflux_63en.zip
```

The domain `paulglagla.com` had a temporary outage which exposed a fragility in the URL construction logic.

## Root cause

`au_GetLatest` was using:
```powershell
$url32 = "https://paulglagla.com/$($page.Links.href | Where-Object {$_ -match "zip$"} | Select-Object -First 1)"
```

This grabs the **first** href ending in `.zip` and prepends `https://paulglagla.com/`. It happened to return the correct file only because `captureflux_63en.zip` appeared first on the page — but the page also contains `ads.zip`, `dvc170.zip`, and `dvc130.zip`, all of which would match `zip$`.

## Fix

Now we first look for the absolute `paulglagla.com/captureflux` URL that is already embedded in the page, and fall back to constructing the URL from the relative link filtered specifically on `captureflux.*\.zip$`. This removes the ordering dependency.

## Testing

Verified:
- `https://paulglagla.com/fichiers/captureflux_63en.zip` returns HTTP 200 (1.85 MB ZIP)
- Page at `http://paul.glagla.free.fr/captureflux_en.htm` contains the absolute download link

Fixes CHO-478.