### PR TITLE
fix(tigervnc): move file downloads from au_GetLatest to au_BeforeUpdate (CHO-485)

### DIFF
--- a/automatic/tigervnc/update.ps1
+++ b/automatic/tigervnc/update.ps1
@@ -1,9 +1,9 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
-$curDir	= "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$curDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $toolsDir = Join-Path $curDir "tools"
-$releases 	= 'https://sourceforge.net/projects/tigervnc/rss?path=/stable'
-$options 	=
+$releases = 'https://sourceforge.net/projects/tigervnc/rss?path=/stable'
+$options  =
 @{
   Headers = @{
     UserAgent = 'Wget';
@@ -23,6 +23,22 @@ function global:au_SearchReplace {
 			"(\<releaseNotes\>).*?(\</releaseNotes\>)"		= "`${1}https://github.com/TigerVNC/tigervnc/releases/tag/$($Latest.Version)`$2"
 		}
 	}
+}
+
+function global:au_BeforeUpdate($Package) {
+	if (-not (Test-Path $toolsDir)) {
+		New-Item -ItemType Directory -Path $toolsDir | Out-Null
+	}
+	. ..\..\scripts\Get-FileVersion.ps1
+	$FileVersion   = Get-FileVersion $Latest.URL32 -keep
+	Move-Item -Path $FileVersion.TempFile -Destination (Join-Path $toolsDir 'tigervnc.exe') -Force
+	$FileVersion64 = Get-FileVersion $Latest.URL64 -keep
+	Move-Item -Path $FileVersion64.TempFile -Destination (Join-Path $toolsDir 'tigervnc64.exe') -Force
+
+	$Latest.Checksum32     = $FileVersion.Checksum
+	$Latest.ChecksumType32 = $FileVersion.ChecksumType
+	$Latest.Checksum64     = $FileVersion64.Checksum
+	$Latest.ChecksumType64 = $FileVersion64.ChecksumType
 }
 
 function global:au_AfterUpdate($Package) {
@@ -60,28 +76,20 @@ function global:au_GetLatest {
 	# breaking the AU retry loop and the VirusTotal scan (Get-RemoteFiles). Keep the permanent
 	# SourceForge /download URLs; Invoke-WebRequest follows the redirect automatically.
 
-	if (-not (Test-Path "tools")) {
-		New-Item -ItemType Directory -Path "tools" | Out-Null
+	# Extract version from URL path (e.g. .../stable/1.16.2/tigervnc64-1.16.2.exe/download)
+	$version = [regex]::Match($url64, '/stable/([^/]+)/').Groups[1].Value
+
+	if (-not $version) {
+		throw "Could not extract version from URL: $url64"
 	}
 
-	. ..\..\scripts\Get-FileVersion.ps1
-	$FileVersion = Get-FileVersion $url32 -keep
-	Move-Item -Path $FileVersion.TempFile -Destination "tools\tigervnc.exe" -Force
-	$FileVersion64 = Get-FileVersion $url64 -keep
-	Move-Item -Path $FileVersion64.TempFile -Destination "tools\tigervnc64.exe" -Force
-
-	$Latest = @{
-		URL32          = $url32
-		URL64          = $url64
-		Version        = $FileVersion.Version
-		Checksum32     = $FileVersion.Checksum
-		ChecksumType32 = $FileVersion.ChecksumType
-		Checksum64     = $FileVersion64.Checksum
-		ChecksumType64 = $FileVersion64.ChecksumType
-		FileName32     = 'tigervnc.exe'
-		FileName64     = 'tigervnc64.exe'
+	return @{
+		URL32      = $url32
+		URL64      = $url64
+		Version    = $version
+		FileName32 = 'tigervnc.exe'
+		FileName64 = 'tigervnc64.exe'
 	}
-	return $Latest
 }
 
 update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
## Problem

`au_GetLatest` was downloading both installer binaries and calling `Move-Item` directly — this violates AU conventions and causes intermittent **file creation errors** in CI because `au_GetLatest` runs on every AU cycle (including no-update heartbeats), not just when a version bump is detected.

## Fix

- Moved `Get-FileVersion` calls and `Move-Item` operations to a new `au_BeforeUpdate` hook (called only on actual version bumps)
- `au_GetLatest` now only fetches the RSS feed, extracts URLs, and derives the version from the URL path (e.g. `.../stable/1.16.2/tigervnc64-1.16.2.exe/download`)
- Used `Join-Path $toolsDir` instead of bare `"tools\"` relative paths for robustness
- `$Latest` checksums/types are populated inside `au_BeforeUpdate` via `$Latest.ChecksumXX =` assignment

## Testing

The version is now read from the SourceForge URL path (regex `/stable/([^/]+)/`), which avoids a full binary download on every heartbeat. `au_BeforeUpdate` only runs when AU detects a version change.

Fixes CHO-485.