### PR TITLE
fix(Executor): use download page URL as base for relative href resolution (CHO-486)

### DIFF
--- a/automatic/Executor/update.ps1
+++ b/automatic/Executor/update.ps1
@@ -25,7 +25,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
 	$downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
-	$url32 = $downloadPage.links | where-object href -match 'E.+\.exe' | select-object -expand href | foreach-object { $base + '/' + $_ } | Select-Object -First 1
+	$url32 = $downloadPage.links | where-object href -match 'E.+\.exe' | select-object -expand href | foreach-object { $releases + '/' + $_ } | Select-Object -First 1
 
 	if (-not $url32) {
 		throw "Could not find EXE download link"


### PR DESCRIPTION
## Problem

`executor.dk/download` page contains a bare relative href: `ExecutorSetup.exe`. The previous code prepended the domain root (`\$base = 'https://executor.dk'`) when building the full URL, producing:

```
https://executor.dk/ExecutorSetup.exe  ← 404
```

But the correct URL is relative to the _page_, not the domain:

```
https://executor.dk/download/ExecutorSetup.exe  ← correct
```

## Fix

Changed `$base + '/' + $_` → `$releases + '/' + $_`, where `$releases = "$base/download"` — the URL of the download page itself. This correctly resolves the bare filename relative to the page URL.

Fixes CHO-486.