### PR TITLE
fix(chromehistoryview): sync nuspec to v1.53 to stop 409 push failures (CHO-487)

### DIFF
--- a/automatic/chromehistoryview/chromehistoryview.nuspec
+++ b/automatic/chromehistoryview/chromehistoryview.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chromehistoryview</id>
-    <version>1.52</version>
+    <version>1.53</version>
     <title>ChromeHistoryView</title>
     <authors>Nir Sofer</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Problem

Every AU run fails with a 409 Conflict when pushing \`chromehistoryview.1.53.0.nupkg\`:

\`\`\`
Response status code does not indicate success: 409 (Conflict).
\`\`\`

This has been occurring daily since the local nuspec was deliberately reverted to 1.52 (commit baeef8e) to force a re-push of 1.53. However, **v1.53 is already on chocolatey.org** — the 409 confirms it exists. The push will never succeed.

The previous fix PR (#4034) was closed without merge (2026-06-15).

## Root Cause

- Local nuspec: `1.52`
- chocolatey.org: `1.53` (already published)
- AU detects `1.52 → 1.53` delta and tries to push, but 1.53 already exists → 409 every run

## Fix

Bump the local nuspec version to `1.53` so AU sees `local == remote` and stops attempting to push.

No checksum change needed — the NirSoft static URL (`chromehistoryview.zip`) already serves 1.53 content and the checksum (`2ec1c491...`) was already updated.

Fixes daily 409 error detected in CHO-487.