### PR TITLE
fix(cura-lulzbot): scrape software.lulzbot.com instead of broken lulzbot.com

### DIFF
--- a/automatic/cura-lulzbot/update.ps1
+++ b/automatic/cura-lulzbot/update.ps1
@@ -1,6 +1,6 @@
-import-module chocolatey-AU
+Import-Module chocolatey-AU
 
-$releases = 'https://lulzbot.com/support/cura-windows'
+$baseUrl = 'https://software.lulzbot.com/Cura_LulzBot_Edition/Windows'
 
 function global:au_SearchReplace {
     @{
@@ -12,21 +12,43 @@ function global:au_SearchReplace {
 }
 
 function global:au_AfterUpdate($Package) {
-	Import-Module ..\..\scripts\au_extensions.psm1
-	Invoke-VirusTotalScan $Package
+    Import-Module ..\..\scripts\au_extensions.psm1
+    Invoke-VirusTotalScan $Package
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $indexPage = Invoke-WebRequest -Uri "$baseUrl/" -UseBasicParsing
 
-    $url = $download_page.links | Where-Object href -match '.exe$' | Where-Object href -notmatch 'BETA' | Select-Object -First 1 -expand href
+    # Get stable version folders only (X.Y.Z pattern, no BETA/alpha suffix in folder name)
+    $versions = $indexPage.links |
+        Select-Object -ExpandProperty href |
+        Where-Object { $_ -match '^\d+\.\d+\.\d+/$' } |
+        ForEach-Object { $_.TrimEnd('/') } |
+        Sort-Object { [version]$_ } -Descending
 
-    $version = $url.Split('/')[-1].split('-') | Where-Object {$_ -NotMatch 'Win'} | Where-Object {$_ -match '\.'} | Where-Object {$_ -notmatch 'exe'}
+    foreach ($ver in $versions) {
+        $versionPage = Invoke-WebRequest -Uri "$baseUrl/$ver/" -UseBasicParsing
 
-    @{
-        URL32 = $url
-        Version = $version
+        # Find a stable .exe: exclude Exp, BETA, alpha, patched variants
+        $exeHref = $versionPage.links |
+            Select-Object -ExpandProperty href |
+            Where-Object { $_ -match '\.exe$' } |
+            Where-Object { $_ -notmatch 'Exp' } |
+            Where-Object { $_ -notmatch 'BETA' } |
+            Where-Object { $_ -notmatch 'alpha' } |
+            Where-Object { $_ -notmatch 'patched' } |
+            Select-Object -First 1
+
+        if ($exeHref) {
+            $url = if ($exeHref -match '^https?://') { $exeHref } else { "$baseUrl/$ver/$exeHref" }
+            return @{
+                URL32   = $url
+                Version = $ver
+            }
+        }
     }
+
+    throw "Could not find a stable Windows installer in $baseUrl"
 }
 
 update -ChecksumFor 32 -NoCheckChocoVersion


### PR DESCRIPTION
## Problem

`lulzbot.com/support/cura-windows` returns HTTP 502 persistently. The AU updater was failing with `au_GetLatest failed; Bad Gateway`.

## Root Cause

LulzBot's main website is down/broken, but the actual download server (`software.lulzbot.com`) is still fully operational and contains all versions including new ones up to 5.10.3.

## Fix

Rewrote `au_GetLatest` in `update.ps1` to scrape `https://software.lulzbot.com/Cura_LulzBot_Edition/Windows/` directly:

1. Fetches the version folder index, extracts stable version folders (`X.Y.Z` pattern only, excluding BETA/alpha suffixes)
2. Sorts by version descending using `[version]` for correct semver ordering
3. For each version (newest first), looks for a stable `.exe` (excluding `Exp`, `BETA`, `alpha`, `patched` variants)
4. Returns the first version/URL found

This approach is resilient to future website changes and correctly picks the latest stable release. The download server also has a newer stable version (5.10.1) that the broken website was never surfacing.

## Versions Available

- Latest stable: `5.10.1` (`Cura_LulzBot_Edition-5.10.1-win64-X64.exe`)
- 5.10.3 exists but is alpha-only (correctly skipped)
- Previous stable: `4.13.17` (current package version)

Closes #CHO-491