### PR TITLE
fix(mpc-qt): hardcode Owner/repo to fix broken URL parsing

### DIFF
--- a/automatic/mpc-qt/update.ps1
+++ b/automatic/mpc-qt/update.ps1
@@ -2,8 +2,8 @@ import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
 
 $releases = 'https://github.com/mpc-qt/mpc-qt/releases/latest'
-$Owner = $releases.Split('/') | Select-Object -Last 1 -Skip 3
-$repo = $releases.Split('/') | Select-Object -Last 1 -Skip 2
+$Owner = 'mpc-qt'
+$repo = 'mpc-qt'
 
 
 function global:au_SearchReplace {


### PR DESCRIPTION
## Problem

`update.ps1` was computing `$Owner` and `$repo` using `Select-Object -Last 1 -Skip N` on the split URL, which in PowerShell first skips N elements from the start and then takes the last 1 — resulting in `'latest'` for both variables instead of `'mpc-qt'`/`'mpc-qt'`.

`Get-GitHubRelease -OwnerName 'latest' -RepositoryName 'latest'` fails every run, causing the "URL syntax is invalid" error in the AU report.

## Fix

Hardcode `$Owner = 'mpc-qt'` and `$repo = 'mpc-qt'` directly, which is simpler and unambiguous.

## Test

The package is currently at version `26.01` which matches the latest GitHub release — AU should report "no update needed" without errors after this fix.

Closes CHO-492 (daily analysis finding).