### PR TITLE
fix(par2cmdline): hardcode Owner/repo to fix broken URL parsing

### DIFF
--- a/automatic/par2cmdline/update.ps1
+++ b/automatic/par2cmdline/update.ps1
@@ -3,8 +3,8 @@ import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
 
 $releases = 'https://api.github.com/repos/Parchive/par2cmdline/releases/latest'
-$Owner = $releases.Split('/') | Select-Object -Last 1 -Skip 3
-$repo = $releases.Split('/') | Select-Object -Last 1 -Skip 2
+$Owner = 'Parchive'
+$repo = 'par2cmdline'
 
 function global:au_SearchReplace {
     @{


### PR DESCRIPTION
## Problem

`update.ps1` computed `$Owner` and `$repo` using `Select-Object -Last 1 -Skip N` on the GitHub API URL. In PowerShell this extracts `'latest'` for both variables instead of `'Parchive'`/`'par2cmdline'`.

`Get-GitHubRelease -OwnerName 'latest' -RepositoryName 'latest'` fails on every AU run, resulting in "invalid version detected" in the AU error report.

## Fix

Hardcode `$Owner = 'Parchive'` and `$repo = 'par2cmdline'` directly.

## Test

Latest release is `v1.2.0` → version `1.2.0`, which matches current nuspec. AU should report "no update needed" without errors.

Closes CHO-492 (daily analysis finding).