### PR TITLE
fix(eagle): add Mozilla UserAgent to prevent 403 on eagle-updates.circuits.io

### DIFF
--- a/automatic/eagle/update.ps1
+++ b/automatic/eagle/update.ps1
@@ -19,7 +19,7 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-    $page = Invoke-WebRequest -Uri $release -UseBasicParsing
+    $page = Invoke-WebRequest -Uri $release -UseBasicParsing -UserAgent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     $url64 = ($page.Links | Where-Object {$_.href -match 'Win_64bit\.exe'} | Select-Object -First 1).href
 
     if (-not $url64) {


### PR DESCRIPTION
## Summary

- The AU runner was getting 403 Forbidden from `eagle-updates.circuits.io` (CloudFront/S3 CDN) when fetching `latest.html` with PowerShell's default user-agent
- The URL itself is functional (confirmed 200 OK with a browser-style UA)  
- Fix: add a Mozilla/Chrome user-agent string to `Invoke-WebRequest` so CDN bot-protection does not block CI requests

## Investigation findings

- `https://eagle-updates.circuits.io/downloads/latest.html` returns 200 OK from browsers and curl
- Download link `https://eagle-updates.circuits.io/downloads/9_6_2/Autodesk_EAGLE_9.6.2_English_Win_64bit.exe` also 200 OK (125 MB, last-modified May 2020)
- Latest version is still 9.6.2 — Autodesk Eagle is discontinued (final release May 2020, product folded into Fusion 360)
- No code logic changes needed; only the UA header was missing

## Test plan

- [ ] AU run should no longer receive 403 when fetching the download page
- [ ] Version detection and URL parsing remain unchanged

Fixes CHO-494

🤖 Generated with [Claude Code](https://claude.ai/claude-code)