### PR TITLE
fix(Executor): fix regex to select current release instead of previousdownloads link

### DIFF
--- a/automatic/Executor/tools/ChocolateyInstall.ps1
+++ b/automatic/Executor/tools/ChocolateyInstall.ps1
@@ -3,8 +3,8 @@
 $packageArgs = @{
     PackageName     = $env:ChocolateyPackageName
     FileType        = 'exe'
-    Url             = 'https://executor.dk/previousdownloads/ExecutorSetup111.exe'
-    Checksum        = '01aadd7208f7715e43d2d9399b41e297ed9127bff6a715bd8b77f158d0076a5c'
+    Url             = 'https://executor.dk/ExecutorSetup.exe'
+    Checksum        = '55bfbe301680bc8c4749080b713e2688050b2ac5742b175a92daf000a6fdc283'
     ChecksumType    = 'sha256'
     SilentArgs      = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 }

--- a/automatic/Executor/update.ps1
+++ b/automatic/Executor/update.ps1
@@ -24,8 +24,8 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-	$downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
-	$url32 = $downloadPage.links | where-object href -match 'E.+\.exe' | select-object -expand href | foreach-object { $base + '/' + $_ } | Select-Object -First 1
+	$downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing -UserAgent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+	$url32 = $downloadPage.links | where-object { $_.href -match '^ExecutorSetup\.exe$' } | select-object -expand href | foreach-object { "$base/$_" } | Select-Object -First 1
 
 	if (-not $url32) {
 		throw "Could not find EXE download link"


### PR DESCRIPTION
## Root cause

The download page at `executor.dk/download` lists both a previous version link (`previousdownloads/ExecutorSetup111.exe`) and the current installer (`ExecutorSetup.exe`). The old regex `E.+\.exe` matched the **previousdownloads** link first (it appears earlier in the DOM), causing AU to:

1. Store the wrong URL (`previousdownloads/ExecutorSetup111.exe`) in `ChocolateyInstall.ps1`
2. Record the correct version (2.3.7) from the RSS feed

This mismatch left the package in an inconsistent state (nuspec says 2.3.7, installer delivers 1.1.1).

The 404 reported in CHO-495 was likely a transient bot-protection rejection on the download page when using PowerShell's default user-agent.

## Changes

- `update.ps1`: Replace broad `'E.+\.exe'` regex with `'^ExecutorSetup\.exe$'` to pin to the current installer only
- `update.ps1`: Add Mozilla UserAgent to `Invoke-WebRequest` to avoid bot-protection 404s
- `tools/ChocolateyInstall.ps1`: Correct URL to `https://executor.dk/ExecutorSetup.exe` and update SHA256 checksum for v2.3.7 (verified: 6.9 MB)

## Test plan

- [ ] `update.ps1` runs without error and returns `Version = 2.3.7`, `Url32 = https://executor.dk/ExecutorSetup.exe`
- [ ] `ChocolateyInstall.ps1` URL resolves and checksum matches
- [ ] Future AU runs will not regress to the previousdownloads link

Closes [CHO-495](/CHO/issues/CHO-495)

🤖 Generated with [Claude Code](https://claude.com/claude-code)