### PR TITLE
fix(install4j): replace choco search with upstream website query

### DIFF
--- a/automatic/install4j/update.ps1
+++ b/automatic/install4j/update.ps1
@@ -2,6 +2,8 @@ $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
 
+$releases = 'https://www.ej-technologies.com/download/install4j/files'
+
 function global:au_SearchReplace {
 	@{
 		"$($Latest.PackageName).nuspec" = @{
@@ -11,18 +13,11 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-	$choc = choco search install4j.install -s https://community.chocolatey.org/api/v2 | Where-Object {$_ -match "install4j.install"}
+	$pageContent = Invoke-WebRequest -Uri $releases
+	$regexPattern = 'version:\s*(\d+(\.\d+)*)'
+	$versionMatch = $pageContent.Content | Select-String -Pattern $regexPattern -AllMatches
 
-	if (-not $choc) {
-		throw "Could not find install4j.install package in Chocolatey repo"
-	}
-
-	$parts = $choc.Split(" ")
-	if ($parts.Count -lt 2) {
-		throw "Could not parse version from choco search result"
-	}
-
-	$version = $parts[1]
+	$version = $versionMatch.Matches[0].Groups[1].Value
 	Update-Metadata -key "copyright" -value "(c) $(Get-Date -Format "yyyy") ej-technologies GmbH"
 
 	$Latest = @{ Version = $version }


### PR DESCRIPTION
## Summary

- Removes `choco search install4j.install` from `install4j/update.ps1` — the choco CLI output format is brittle and was causing an AU "unknown file type" error
- Replaces with a direct query to `https://www.ej-technologies.com/download/install4j/files`, the same source already used by `install4j.install` and `install4j.portable`
- Version is parsed via the same regex pattern (`version:\s*(\d+(\.\d+)*)`) used in sibling packages

## Root cause

The AU error "unknown file type encountered" was triggered because `choco search` output format (changed in Chocolatey CLI v2) could not be reliably parsed with `$parts[1]`. When `$version` was empty/invalid, AU failed during package update processing.

## Test plan

- [ ] Verify `.\update.ps1` in `automatic/install4j/` runs without error and returns version matching the `.install` package
- [ ] Confirm AppVeyor CI passes on this PR

Fixes: CHO-496