### PR TITLE
fix(osfmount): replace HTML scraping with direct EXE version extraction

### DIFF
--- a/automatic/osfmount/update.ps1
+++ b/automatic/osfmount/update.ps1
@@ -25,15 +25,12 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$releases='https://www.osforensics.com/tools/mount-disk-images.html'
-	$page = Invoke-WebRequest -Uri $releases -UseBasicParsing -Headers @{'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'}
-	$regexPattern = 'OSFMount V(\d+(\.\d+)*)'
-	$versionMatch = $page.Content | Select-String -Pattern $regexPattern -AllMatches
-	$version = $versionMatch.Matches[0].Groups[1].Value
-	$url32 = "https://www.osforensics.com/downloads/osfmount.exe"
+	$url32 = 'https://www.osforensics.com/downloads/osfmount.exe'
+	. ..\..\scripts\Get-FileVersion.ps1
+	$FileVersion = Get-FileVersion $url32
+	$version = $FileVersion.Version
 
-	$Latest = @{ URL32 = $url32; Version = $version }
-	return $Latest
+	return @{ URL32 = $url32; Version = $version }
 }
 
 update -NoCheckUrl -ChecksumFor none


### PR DESCRIPTION
## Summary

- `osforensics.com` returns 403 Forbidden on CI IPs when fetching the HTML version page, even with a browser User-Agent header
- The download URL (`/downloads/osfmount.exe`) is a static link to the latest release and is publicly accessible without special headers
- Replaces HTML scraping in `au_GetLatest` with direct EXE version extraction via `Get-FileVersion`, reading the PE version info from the downloaded binary

## Test plan

- [ ] `au_GetLatest` no longer makes an HTTP request to the 403-blocked HTML page
- [ ] Version is extracted from PE FileVersionInfo of the downloaded EXE
- [ ] `au_BeforeUpdate` continues to download and keep the EXE for packaging (unchanged)
- [ ] CI/AppVeyor run passes without 403 errors

Fixes CHO-498