### PR TITLE
fix(vnc-connect): add browser User-Agent header to bypass 403 (CHO-504)

### DIFF
--- a/automatic/vnc-connect/update.ps1
+++ b/automatic/vnc-connect/update.ps1
@@ -26,7 +26,8 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$page = (Invoke-WebRequest -Uri $releases -UseBasicParsing).Content
+	$headers = @{ 'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' }
+	$page = (Invoke-WebRequest -Uri $releases -UseBasicParsing -Headers $headers).Content
 	$regex = 'data-file="(https://downloads\.realvnc\.com/download/file/vnc\.files/VNC-Server-[^"]+-Windows-msi\.zip)"'
 	if ($page -match $regex) {
 		$url32 = $matches[1]


### PR DESCRIPTION
## Summary

- Adds a Chrome browser User-Agent header to `Invoke-WebRequest` in `update.ps1`
- Fixes the 403 Forbidden error when scraping `https://realvnc.com/en/connect/download/vnc/`
- Root cause: RealVNC blocks PowerShell's default user-agent (`WindowsPowerShell/5.1.x`)

## Root Cause Analysis

The page returns 200 with standard curl but 403 with PowerShell's `Invoke-WebRequest` because RealVNC blocks automated user-agents. Adding a browser-like User-Agent header resolves the issue — confirmed working from Linux (`curl -sL`).

## Test plan

- [ ] Verify `update.ps1` runs without 403 on AppVeyor CI
- [ ] Confirm version detection matches current release (7.17.0)

Fixes: CHO-504