### PR TITLE
Fix pwgen update.ps1: get version from SourceForge instead of choco search

### DIFF
--- a/automatic/pwgen/pwgen.nuspec
+++ b/automatic/pwgen/pwgen.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>pwgen</id>
-    <version>3.6.0</version>
-    <title>PWTech</title>
+    <version>3.5.7</version>
+    <title>PWGen</title>
     <authors>Christian Thoeing</authors>
     <owners>tunisiano</owners>
     <licenseUrl>https://www.gnu.org/licenses/gpl-2.0.html</licenseUrl>
@@ -39,7 +39,7 @@ Support the package maintainer and [![Patreon](https://cdn.jsdelivr.net/gh/tunis
     <packageSourceUrl>https://github.com/tunisiano187/Chocolatey-packages/tree/master/automatic/pwgen</packageSourceUrl>
     <bugTrackerUrl>https://sourceforge.net/p/pwgen-win/bugs/</bugTrackerUrl>
     <dependencies>
-      <dependency id="pwgen.install" version="[3.6.0]" />
+      <dependency id="pwgen.install" version="[3.5.7]" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/pwgen/pwgen.nuspec
+++ b/automatic/pwgen/pwgen.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>pwgen</id>
-    <version>3.5.7</version>
-    <title>PWGen</title>
+    <version>3.6.0</version>
+    <title>PWTech</title>
     <authors>Christian Thoeing</authors>
     <owners>tunisiano</owners>
     <licenseUrl>https://www.gnu.org/licenses/gpl-2.0.html</licenseUrl>
@@ -39,7 +39,7 @@ Support the package maintainer and [![Patreon](https://cdn.jsdelivr.net/gh/tunis
     <packageSourceUrl>https://github.com/tunisiano187/Chocolatey-packages/tree/master/automatic/pwgen</packageSourceUrl>
     <bugTrackerUrl>https://sourceforge.net/p/pwgen-win/bugs/</bugTrackerUrl>
     <dependencies>
-      <dependency id="pwgen.install" version="[3.5.7]" />
+      <dependency id="pwgen.install" version="[3.6.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/pwgen/update.ps1
+++ b/automatic/pwgen/update.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 
-$releases = 'https://sourceforge.net/projects/pwgen-win/files/Password%20Tech/'
+$releases = 'https://sourceforge.net/projects/pwgen-win/rss?path=/Password%20Tech'
 
 function global:au_SearchReplace {
 	@{
@@ -12,11 +12,12 @@ function global:au_SearchReplace {
  }
 
 function global:au_GetLatest {
-	$choc=$(choco search pwgen.install | Where-Object {$_ -match "pwgen.install"})
-	$version = $choc.Split(" ")[1]
+	[xml]$xml = (Invoke-WebRequest -Uri $releases -UseBasicParsing).Content
+	$item = $xml.rss.channel.item | Where-Object { $_.link -match '(?i)Setup\.exe/download' -and $_.link -notmatch '\.sig/' } | Select-Object -First 1
+	if ($null -eq $item) { throw "Could not find Setup.exe in SourceForge RSS feed for Password Tech" }
+	$version = [regex]::Match($item.link, 'Password%20Tech/([^/]+)/').Groups[1].Value
 
-	$Latest = @{ Version = $version }
-	return $Latest
+	@{ Version = $version }
 }
 
 update -ChecksumFor none -NoCheckUrl


### PR DESCRIPTION
## Summary

Related to #4102

Fixes the root cause of why `pwgen` (the meta-package) never auto-updates: `au_GetLatest` was calling `choco search pwgen.install` to determine the latest version. This only sees what is **already published to Chocolatey.org**, so `pwgen` can never detect an upstream release until `pwgen.install` is already live — a circular dependency that prevents AU from ever triggering an update.

**Fix:** replace `choco search` with a direct SourceForge RSS feed lookup, matching the same approach already used by `pwgen.install/update.ps1`.

## Changes

- `update.ps1`: replace `choco search pwgen.install` with SourceForge RSS query; add null-safety guard