### PR TITLE
fix(nteract.install): accept exit code 2 as valid NSIS install success

### DIFF
--- a/automatic/nteract.install/tools/chocolateyInstall.ps1
+++ b/automatic/nteract.install/tools/chocolateyInstall.ps1
@@ -19,7 +19,7 @@ $packageArgs = @{
   checksumType  = $checksumType
 
   silentArgs   = '/S' # NSIS
-  validExitCodes= @(0)
+  validExitCodes= @(0, 2)
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
## Problem

`nteract.install` v2.6.2 is "Waiting for Maintainer". The nteract installer is Electron/NSIS-based and returns exit code **2** even when installation succeeds. With `validExitCodes = @(0)`, Chocolatey rejects this as a failure.

This is the same pattern as [#4108](https://github.com/tunisiano187/Chocolatey-packages/pull/4108) (ossec-client) where exit code 2 from a NSIS installer signals success.

## Fix

Added `2` to `validExitCodes`:

```powershell
# Before
validExitCodes= @(0)

# After
validExitCodes= @(0, 2)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_