### PR TITLE
fix(nteract.install): reset version to 0.0 to trigger AU re-submission

### DIFF
--- a/automatic/nteract.install/nteract.install.nuspec
+++ b/automatic/nteract.install/nteract.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>nteract.install</id>
-    <version>2.6.2</version>
+    <version>0.0</version>
     <title>nteract (Install)</title>
     <authors>nteract contributors</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Summary

- Resets `nteract.install` nuspec version to `0.0` so AU detects it as outdated and re-pushes the package with the corrected exit code handling (accepted in PR #4110) to chocolatey.org.
- `update.ps1` already had `-NoCheckChocoVersion`.

## Test plan

- [ ] AU runs, detects version mismatch (0.0 vs current upstream), re-packages and re-submits to chocolatey.org with exit code 2 accepted as valid NSIS success.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_