### PR TITLE
fix(transmission): reset version to 0.0 and add -NoCheckChocoVersion

### DIFF
--- a/automatic/transmission/transmission.nuspec
+++ b/automatic/transmission/transmission.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>transmission</id>
-    <version>4.1.3</version>
+    <version>0.0</version>
     <title>Transmission</title>
     <authors>Transmission Project</authors>
     <owners>tunisiano</owners>

--- a/automatic/transmission/update.ps1
+++ b/automatic/transmission/update.ps1
@@ -41,4 +41,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update
+update -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

- Resets `transmission` nuspec version to `0.0` to trigger AU re-submission.
- Adds `-NoCheckChocoVersion` to `update.ps1`.

The test failure (exit code 1: "package not found") was caused by a transient HTTP 503 from `community.chocolatey.org` during the test run, not an actual package defect. Re-triggering via AU will resolve the "Waiting for Maintainer" status.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_