### PR TITLE
fix(tigervnc): reset version to 0.0 to trigger AU re-submission

### DIFF
--- a/automatic/tigervnc/tigervnc.nuspec
+++ b/automatic/tigervnc/tigervnc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>tigervnc</id>
-    <version>1.16.2</version>
+    <version>0.0</version>
     <title>TigerVNC</title>
     <authors>TigerVNC Team et al.</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Summary

- Resets `tigervnc` nuspec version to `0.0` to trigger AU re-submission.
- `update.ps1` already has `-NoCheckChocoVersion`.

The test failure (exit code 1: "package not found") was caused by a transient HTTP 503 from `community.chocolatey.org` during the test run, not an actual package defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_