### PR TITLE
fix(faceit): reset version to 0.0 to trigger AU re-submission with fresh checksum

### DIFF
--- a/automatic/faceit/Faceit.nuspec
+++ b/automatic/faceit/Faceit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>faceit</id>
-    <version>2.8.4</version>
+    <version>0.0</version>
     <title>Faceit</title>
     <authors>Faceit</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Summary

- Resets `faceit` nuspec version to `0.0`.
- `update.ps1` already has `-NoCheckChocoVersion`.

The test failure (exit -1: SHA256 checksum mismatch on `FACEIT-setup-latest.exe`) occurred because the upstream rolling installer was updated after the package was submitted, invalidating the stored checksum. Resetting to `0.0` causes AU to re-download the current binary and recalculate the correct hash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_