### PR TITLE
fix(install4j): reset version to 0.0 and add -NoCheckChocoVersion

### DIFF
--- a/automatic/install4j/install4j.nuspec
+++ b/automatic/install4j/install4j.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>install4j</id>
-    <version>13.0.2</version>
+    <version>0.0</version>
     <title>install4j</title>
     <authors>Dr Ingo Kegel</authors>
     <owners>tunisiano</owners>

--- a/automatic/install4j/update.ps1
+++ b/automatic/install4j/update.ps1
@@ -24,4 +24,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

- Resets `install4j` nuspec version to `0.0`.
- Adds `-NoCheckChocoVersion` to `update.ps1`.

Version 13.0.0 failed with SHA256 mismatch (upstream binary was silently replaced after submission). The repo is already at 13.0.2 which passes. Resetting to `0.0` causes AU to re-push the current passing version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_