### PR TITLE
fix(install4j.install): reset version to 0.0 and add -NoCheckChocoVersion

### DIFF
--- a/automatic/install4j.install/install4j.install.nuspec
+++ b/automatic/install4j.install/install4j.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>install4j.install</id>
-    <version>13.0.2</version>
+    <version>0.0</version>
     <title>install4j (Install)</title>
     <authors>Dr Ingo Kegel</authors>
     <owners>tunisiano</owners>

--- a/automatic/install4j.install/update.ps1
+++ b/automatic/install4j.install/update.ps1
@@ -34,4 +34,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor 32 -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

- Resets `install4j.install` nuspec version to `0.0`.
- Adds `-NoCheckChocoVersion` to `update.ps1`.

Version 13.0.0 failed with SHA256 mismatch (upstream binary was silently replaced). Repo is already at 13.0.2 which passes. Resetting to `0.0` triggers AU to re-push the current passing version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_