### PR TITLE
fix(mpc-qt): use recursive exe search after zip extraction

### DIFF
--- a/automatic/mpc-qt/mpc-qt.nuspec
+++ b/automatic/mpc-qt/mpc-qt.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>mpc-qt</id>
-    <version>26.07</version>
+    <version>0.0</version>
     <title>MPC QT</title>
     <authors>https://github.com/mpc-qt/mpc-qt/graphs/contributors</authors>
     <owners>tunisiano</owners>

--- a/automatic/mpc-qt/tools/chocolateyInstall.ps1
+++ b/automatic/mpc-qt/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
 
 Get-ChocolateyUnzip @packageArgs
 
-$fileLocation = Get-Item "$toolsDir\mpc-qt\*-qt.exe"
+$fileLocation = Get-ChildItem "$toolsDir\mpc-qt" -Recurse -Filter "*-qt.exe" | Select-Object -First 1 -ExpandProperty FullName
 $shortcutName = 'MPC-QT.lnk'
 
 Install-ChocolateyShortcut -shortcutFilePath "$env:Public\Desktop\$shortcutName" -targetPath "$fileLocation" -WorkingDirectory "$toolsDir\mpc-qt"


### PR DESCRIPTION
## Summary

- Fixes `chocolateyInstall.ps1`: replaces `Get-Item "$toolsDir\mpc-qt\*-qt.exe"` with `Get-ChildItem -Recurse -Filter "*-qt.exe" | Select-Object -First 1 -ExpandProperty FullName`.
- Resets nuspec version to `0.0` so AU re-packages and re-submits.

The test failure (exit -1: `Cannot bind argument to parameter 'targetPath' because it is an empty string`) occurred because `Get-Item` with a flat glob returns nothing when the archive extracts the exe into a subdirectory. The recursive `Get-ChildItem` call finds the exe regardless of nesting depth inside the extraction folder.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_