### PR TITLE
fix(openhab): reset version to 0.0 to trigger AU re-submission

### DIFF
--- a/automatic/openhab/openhab.nuspec
+++ b/automatic/openhab/openhab.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>openhab</id>
-    <version>5.2.0</version>
+    <version>0.0</version>
     <title>openHAB</title>
     <authors>openHAB Community and the openHAB Foundation</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Summary

- Resets `openhab` nuspec version to `0.0`.
- `update.ps1` already has `-NoCheckChocoVersion`.

The test failure (exit 2: 7-Zip fatal error, `openhab-5.2.0.zip` not found in tools directory) indicates the embedded ZIP was missing from the nupkg. Resetting to `0.0` causes AU to re-download and re-embed the ZIP when building the next nupkg.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_