### PR TITLE
fix(soundvolumeview): reset version to 0.0 to trigger AU re-submission

### DIFF
--- a/automatic/soundvolumeview/soundvolumeview.nuspec
+++ b/automatic/soundvolumeview/soundvolumeview.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>soundvolumeview</id>
-    <version>2.53</version>
+    <version>0.0</version>
     <title>SoundVolumeView</title>
     <authors>Nir Sofer</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
## Summary

- Resets `soundvolumeview` nuspec version to `0.0`.
- `update.ps1` already has `-NoCheckChocoVersion`.

The test failure (exit 2: 7-Zip fatal error, `soundvolumeview-x64.zip` not found — only a `.txt` placeholder present) indicates the embedded ZIPs were not included in the nupkg. Resetting to `0.0` causes AU to re-download both 32-bit and 64-bit ZIPs and re-embed them on the next run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_