### PR TITLE
fix(Executor): reset version to 0.0 to force AU re-submission

### DIFF
--- a/automatic/Executor/Executor.nuspec
+++ b/automatic/Executor/Executor.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>Executor</id>
     <title>Executor</title>
-    <version>2.3.10</version>
+    <version>0.0</version>
     <authors>Martin Bresson</authors>
     <owners>tunisiano</owners>
     <packageSourceUrl>https://github.com/tunisiano187/Chocolatey-packages/tree/master/automatic/Executor</packageSourceUrl>


### PR DESCRIPTION
## Summary

- Resets `Executor` nuspec version to `0.0` to force AU re-submission.
- `update.ps1` already has `-NoCheckChocoVersion -NoCheckUrl`.

Package appears absent from the Chocolatey community repository. Resetting to `0.0` causes AU to re-detect the current version (2.3.10) and re-push it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGegpfx6ABqYZXPCJCcHGs)_