### PR TITLE
fix(tdarr-updater): switch from embedded zip to URL-based download

### DIFF
--- a/automatic/tdarr-updater/tdarr-updater.nuspec
+++ b/automatic/tdarr-updater/tdarr-updater.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>tdarr-updater</id>
-    <version>2.81.1</version>
+    <version>0.0</version>
     <title>Tdarr Updater (Portable)</title>
     <authors>HaveAGitGat</authors>
     <owners>tunisiano</owners>

--- a/automatic/tdarr-updater/tools/chocolateyInstall.ps1
+++ b/automatic/tdarr-updater/tools/chocolateyInstall.ps1
@@ -1,16 +1,16 @@
-﻿$ErrorActionPreference = 'Stop'
-$packageName      = 'tdarr-updater'
-$toolsDir         = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$ErrorActionPreference = 'Stop'
+$packageName = 'tdarr-updater'
+$toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
-  packageName    = $packageName
-  Destination    = "$env:ProgramFiles\Tdarr"
-  FileFullPath   = "$toolsDir\Tdarr_Updater.zip"
+  packageName   = $packageName
+  unzipLocation = "$env:ProgramFiles\Tdarr"
+  url           = 'https://storage.tdarr.io/versions/2.81.01/win32_x64/Tdarr_Updater.zip'
+  checksum      = '0BE065C21C124AFA56CC265C5F132243140C1424F58935F283BE479C6FCC472E'
+  checksumType  = 'sha256'
 }
 
-Get-ChocolateyUnzip @packageArgs
-
-Remove-Item "$toolsDir\*.zip" -EA SilentlyContinue | Out-Null
+Install-ChocolateyZipPackage @packageArgs
 
 Get-ChildItem -Path $env:ProgramFiles\Tdarr -Recurse | Where-Object {
   $_.Extension -eq '.exe'
@@ -24,4 +24,3 @@ Install-ChocolateyShortcut -shortcutFilePath "$env:Public\Desktop\Tdarr_Server.l
 Install-ChocolateyShortcut -shortcutFilePath "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Tdarr\Tdarr_Server.lnk" -targetPath "$env:ProgramFiles\Tdarr\Tdarr_Server\Tdarr_Server.exe" -WorkingDirectory "$env:ProgramFiles\Tdarr\Tdarr_Server" -RunAsAdmin
 Install-ChocolateyShortcut -shortcutFilePath "$env:Public\Desktop\Tdarr_Node.lnk" -targetPath "$env:ProgramFiles\Tdarr\Tdarr_Node\Tdarr_Node.exe" -WorkingDirectory "$env:ProgramFiles\Tdarr\Tdarr_Node" -RunAsAdmin
 Install-ChocolateyShortcut -shortcutFilePath "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Tdarr\Tdarr_Node.lnk" -targetPath "$env:ProgramFiles\Tdarr\Tdarr_Node\Tdarr_Node.exe" -WorkingDirectory "$env:ProgramFiles\Tdarr\Tdarr_Node" -RunAsAdmin
-

--- a/automatic/tdarr-updater/update.ps1
+++ b/automatic/tdarr-updater/update.ps1
@@ -1,24 +1,21 @@
 $ErrorActionPreference = 'Stop'
-import-module chocolatey-AU
+import-module Chocolatey-AU
 
 $releases = 'https://docs.tdarr.io/docs/installation/windows-linux-macos'
 
 function global:au_SearchReplace {
 	@{
-		"legal\VERIFICATION.txt"      = @{
-			"(?i)(x86:).*"      		= "`${1} $($Latest.URL32)"
-			"(?i)(checksum:).*" 		= "`${1} $($Latest.Checksum32)"
-			"(?i)(checksum Type:).*" 	= "`${1} $($Latest.ChecksumType32)"
+		'tools/chocolateyInstall.ps1' = @{
+			"(url\s*=\s*)'.*'"          = "`$1'$($Latest.URL32)'"
+			"(checksum\s*=\s*)'.*'"     = "`$1'$($Latest.Checksum32)'"
+			"(checksumType\s*=\s*)'.*'" = "`$1'$($Latest.ChecksumType32)'"
+		}
+		"legal\VERIFICATION.txt" = @{
+			"(?i)(x86:).*"           = "`${1} $($Latest.URL32)"
+			"(?i)(checksum:).*"      = "`${1} $($Latest.Checksum32)"
+			"(?i)(checksum Type:).*" = "`${1} $($Latest.ChecksumType32)"
 		}
 	}
-}
-
-function global:au_BeforeUpdate {
-	. ..\..\scripts\Get-FileVersion.ps1
-	$FileVersion = Get-FileVersion $Latest.URL32 -keep
-	Move-Item -Path $FileVersion.TempFile -Destination "tools\Tdarr_Updater.zip"
-	$Latest.Checksum32 = $FileVersion.Checksum
-	$Latest.ChecksumType32 = $FileVersion.checksumType
 }
 
 function global:au_AfterUpdate($Package) {
@@ -27,12 +24,13 @@ function global:au_AfterUpdate($Package) {
 }
 
 function global:au_GetLatest {
-	$url32 		= (((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_ -match 'win32_x64/Tdarr_Updater.zip'}).href)
-	$version 	= Get-Version $url32
+	$url32   = (((Invoke-WebRequest -Uri $releases -UseBasicParsing).Links | Where-Object {$_ -match 'win32_x64/Tdarr_Updater.zip'}).href)
+	$version = Get-Version $url32
 
+	. ..\..\scripts\Get-FileVersion.ps1
+	$FileVersion = Get-FileVersion $url32
 
-	$Latest = @{ URL32 = $url32; Version = $version }
-	return $Latest
+	return @{ URL32 = $url32; Version = $version; Checksum32 = $FileVersion.Checksum; ChecksumType32 = $FileVersion.ChecksumType }
 }
 
 update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
## Problème

`tdarr-updater` embarquait `Tdarr_Updater.zip` dans le nupkg via `au_BeforeUpdate`. Ce binaire n'était **jamais commité dans git** — il n'existait que pendant l'exécution d'AU sur une montée de version.

Conséquence : tout repack qui ne passe pas par `au_BeforeUpdate` (re-push même-version avec `-NoCheckChocoVersion`, workflow `push-package.yml`) produisait un nupkg cassé sans le zip. C'est la cause récurrente du test choco-bot échoué avec "The system cannot find the file specified" / 7-Zip exit code 2.

La racine est que `push-package.yml` cherche le pattern `x32:` dans VERIFICATION.txt et `\bfile\b` dans chocolateyInstall.ps1 — ni l'un ni l'autre ne correspond aux patterns réels de ce paquet (`x86:` et `FileFullPath`), donc le re-download est silencieusement ignoré.

## Corrections

- **`chocolateyInstall.ps1`** : remplace `Get-ChocolateyUnzip` (fichier local) par `Install-ChocolateyZipPackage` (URL + checksum). Le zip est désormais téléchargé à l'install depuis la source upstream, sans binaire embarqué.
- **`update.ps1`** : supprime `au_BeforeUpdate` (plus nécessaire). Déplace le calcul du checksum dans `au_GetLatest`. Ajoute des entrées `au_SearchReplace` pour patcher l'URL et le checksum dans `chocolateyInstall.ps1` à chaque version.
- **`tdarr-updater.nuspec`** : version → `0.0` pour forcer AU à re-soumettre le paquet corrigé (avec `-NoCheckChocoVersion` déjà présent).

---
_Generated by [Claude Code](https://claude.ai/code/session_0191qKSGMvE57BC4YULat79h)_