### PR TITLE
fix(tigervnc): switch from embedded EXE to URL-based download

### DIFF
--- a/automatic/tigervnc/tigervnc.nuspec
+++ b/automatic/tigervnc/tigervnc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>tigervnc</id>
-    <version>1.16.2</version>
+    <version>0.0</version>
     <title>TigerVNC</title>
     <authors>TigerVNC Team et al.</authors>
     <owners>tunisiano</owners>

--- a/automatic/tigervnc/tools/chocolateyInstall.ps1
+++ b/automatic/tigervnc/tools/chocolateyInstall.ps1
@@ -1,21 +1,19 @@
-$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop'
 
-$packageName      = $env:ChocolateyPackageName
-$toolsDir         = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$file             = Join-Path $toolsDir '/tigervnc.exe'
-$file64           = Join-Path $toolsDir '/tigervnc64.exe'
+$packageName = $env:ChocolateyPackageName
 
 $packageArgs = @{
-  packageName     = $packageName
-  unzipLocation   = $toolsDir
-  fileType        = 'EXE'
-  file            = $file
-  file64          = $file64
-
-  softwareName    = 'tigervnc*'
-
-  validExitCodes  = @(0)
-  silentArgs      = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+  packageName    = $packageName
+  fileType       = 'EXE'
+  url            = 'https://sourceforge.net/projects/tigervnc/files/stable/1.16.2/tigervnc-1.16.2.exe/download'
+  url64bit       = 'https://sourceforge.net/projects/tigervnc/files/stable/1.16.2/tigervnc64-1.16.2.exe/download'
+  checksum       = 'BD1DEF637465DD51A5A51B1C40A37BD9E5E52123BF9CE5AA135B9E35AFB02F10'
+  checksumType   = 'sha256'
+  checksum64     = '96A0117C8D0D55EA2E2C20E3D9D9A798011DA8C5A813A35CD0B9E006D58BB7F4'
+  checksumType64 = 'sha256'
+  softwareName   = 'tigervnc*'
+  validExitCodes = @(0)
+  silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 }
 
-Install-ChocolateyInstallPackage @packageArgs
+Install-ChocolateyPackage @packageArgs

--- a/automatic/tigervnc/update.ps1
+++ b/automatic/tigervnc/update.ps1
@@ -1,44 +1,28 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
-$curDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$toolsDir = Join-Path $curDir "tools"
 $releases = 'https://sourceforge.net/projects/tigervnc/rss?path=/stable'
-$options  =
-@{
-  Headers = @{
-    UserAgent = 'Wget';
-  }
-}
 
 function global:au_SearchReplace {
 	@{
-		"legal\VERIFICATION.txt"      = @{
-			"(?i)(link32:).*"        			= "`${1} $($Latest.URL32)"
-			"(?i)(checksum32:).*" 				= "`${1} $($Latest.Checksum32)"
-			"(?i)(checksumtype:).*" 			= "`${1} $($Latest.ChecksumType32)"
-			"(?i)(link64:).*"        			= "`${1} $($Latest.URL64)"
-			"(?i)(checksum64:).*" 				= "`${1} $($Latest.Checksum64)"
+		'tools/chocolateyInstall.ps1' = @{
+			"(url\s*=\s*)'.*'"             = "`$1'$($Latest.URL32)'"
+			"(url64bit\s*=\s*)'.*'"        = "`$1'$($Latest.URL64)'"
+			"(checksum\s*=\s*)'.*'"        = "`$1'$($Latest.Checksum32)'"
+			"(checksumType\s*=\s*)'.*'"    = "`$1'$($Latest.ChecksumType32)'"
+			"(checksum64\s*=\s*)'.*'"      = "`$1'$($Latest.Checksum64)'"
+			"(checksumType64\s*=\s*)'.*'"  = "`$1'$($Latest.ChecksumType64)'"
+		}
+		"legal\VERIFICATION.txt" = @{
+			"(?i)(link32:).*"       = "`${1} $($Latest.URL32)"
+			"(?i)(checksum32:).*"   = "`${1} $($Latest.Checksum32)"
+			"(?i)(checksumtype:).*" = "`${1} $($Latest.ChecksumType32)"
+			"(?i)(link64:).*"       = "`${1} $($Latest.URL64)"
+			"(?i)(checksum64:).*"   = "`${1} $($Latest.Checksum64)"
 		}
 		"$($Latest.PackageName).nuspec" = @{
-			"(\<releaseNotes\>).*?(\</releaseNotes\>)"		= "`${1}https://github.com/TigerVNC/tigervnc/releases/tag/$($Latest.Version)`$2"
+			"(\<releaseNotes\>).*?(\</releaseNotes\>)" = "`${1}https://github.com/TigerVNC/tigervnc/releases/tag/$($Latest.Version)`$2"
 		}
 	}
-}
-
-function global:au_BeforeUpdate($Package) {
-	if (-not (Test-Path $toolsDir)) {
-		New-Item -ItemType Directory -Path $toolsDir | Out-Null
-	}
-	. ..\..\scripts\Get-FileVersion.ps1
-	$FileVersion   = Get-FileVersion $Latest.URL32 -keep
-	Move-Item -Path $FileVersion.TempFile -Destination (Join-Path $toolsDir 'tigervnc.exe') -Force
-	$FileVersion64 = Get-FileVersion $Latest.URL64 -keep
-	Move-Item -Path $FileVersion64.TempFile -Destination (Join-Path $toolsDir 'tigervnc64.exe') -Force
-
-	$Latest.Checksum32     = $FileVersion.Checksum
-	$Latest.ChecksumType32 = $FileVersion.ChecksumType
-	$Latest.Checksum64     = $FileVersion64.Checksum
-	$Latest.ChecksumType64 = $FileVersion64.ChecksumType
 }
 
 function global:au_AfterUpdate($Package) {
@@ -83,12 +67,18 @@ function global:au_GetLatest {
 		throw "Could not extract version from URL: $url64"
 	}
 
+	. ..\..\scripts\Get-FileVersion.ps1
+	$fv32 = Get-FileVersion $url32
+	$fv64 = Get-FileVersion $url64
+
 	return @{
-		URL32      = $url32
-		URL64      = $url64
-		Version    = $version
-		FileName32 = 'tigervnc.exe'
-		FileName64 = 'tigervnc64.exe'
+		URL32          = $url32
+		URL64          = $url64
+		Version        = $version
+		Checksum32     = $fv32.Checksum
+		ChecksumType32 = $fv32.ChecksumType
+		Checksum64     = $fv64.Checksum
+		ChecksumType64 = $fv64.ChecksumType
 	}
 }
 


### PR DESCRIPTION
## Problème

`tigervnc` embarquait `tigervnc.exe` et `tigervnc64.exe` dans le nupkg via `au_BeforeUpdate`. Ces binaires n'étaient **jamais commités dans git** — ils n'existaient que pendant l'exécution d'AU sur une montée de version.

Conséquence : tout repack sans passer par `au_BeforeUpdate` produisait un nupkg vide d'exécutables. Le workflow `push-package.yml` est censé compenser mais cherche `x32:`/`x64:` dans VERIFICATION.txt (tigervnc a `link32:`/`link64:`) et `file = "..."` dans chocolateyInstall.ps1 (tigervnc utilise `Join-Path`) → le re-download est silencieusement ignoré à chaque re-push. C'est la cause récurrente du test choco-bot échoué : "The system cannot find the file specified".

## Corrections

- **`chocolateyInstall.ps1`** : remplace `Install-ChocolateyInstallPackage` (fichiers locaux) par `Install-ChocolateyPackage` avec `url`, `url64bit`, `checksum`, `checksum64`. Plus aucun binaire embarqué.
- **`update.ps1`** : supprime `au_BeforeUpdate`. Déplace le calcul des checksums (32 et 64 bits) dans `au_GetLatest`. Ajoute des entrées `au_SearchReplace` pour patcher `url`, `url64bit` et les deux checksums dans `chocolateyInstall.ps1` à chaque version.
- **`tigervnc.nuspec`** : version → `0.0` pour forcer AU à re-soumettre le paquet corrigé (avec `-NoCheckChocoVersion` déjà présent).

---
_Generated by [Claude Code](https://claude.ai/code/session_0191qKSGMvE57BC4YULat79h)_