### PR TITLE
fix(projectlibre.install): bump nuspec to 1.9.8 and fix VERIFICATION.txt

### DIFF
--- a/automatic/projectlibre.install/projectlibre.install.nuspec
+++ b/automatic/projectlibre.install/projectlibre.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>projectlibre.install</id>
-    <version>1.9.3</version>
+    <version>1.9.8</version>
     <title>ProjectLibre</title>
     <authors>ProjectLibre</authors>
     <owners>tunisiano</owners>

--- a/automatic/projectlibre.install/tools/VERIFICATION.txt
+++ b/automatic/projectlibre.install/tools/VERIFICATION.txt
@@ -4,14 +4,15 @@ in verifying that this package's contents are trustworthy.
 
 1.  Download the installer:
 
-    x32: https://github.com/Ryochan7/DS4Windows/releases/download/v3.1.11/DS4Windows_3.1.11_x64.zip
+    x32: https://downloads.sourceforge.net/project/projectlibre/ProjectLibre/1.9.8/ProjectLibre-1.9.8.msi
+    OR
+    x32: https://sourceforge.net/projects/projectlibre/files/ProjectLibre/1.9.8/ProjectLibre-1.9.8.msi/download
 
-2.  You can use one of the following methods to obtain the checksum: 
+2.  You can use one of the following methods to obtain the checksum:
     - Use powershell function 'Get-FileHash'
     - Use Chocolatey utility 'checksum.exe'
-    - Using AU:
-        Get-RemoteChecksum https://github.com/Ryochan7/DS4Windows/releases/download/v3.1.11/DS4Windows_3.1.11_x64.zip
 
 3.  Compare to Checksum:
 
-    checksum32: 343F507682F5F0D799C99135DA1E812E1FB972CE6CCC27ACC7304FD1D5C99A24
+    checksum32: 32e46ba3ce7b3a81dc8ec648f6baf8f6f6056c8cf9203f75f8187e9e4637833f
+    checksumType32: sha256


### PR DESCRIPTION
Fixes #4123

Proposed changes in this pull request:
- Bump `projectlibre.install.nuspec` version from `1.9.3` to `1.9.8` to match the existing `chocolateyInstall.ps1` (which already references the v1.9.8 MSI URL and sha256 checksum)
- Replace `tools/VERIFICATION.txt` — it contained DS4Windows content instead of ProjectLibre; now correctly lists the ProjectLibre 1.9.8 MSI URL and checksum

**Root cause**: `chocolateyInstall.ps1` was previously updated to v1.9.8 but the nuspec version was never bumped to match, preventing AU from publishing the 1.9.8 package to chocolatey.org. The `projectlibre` meta-package will auto-update once `projectlibre.install` 1.9.8 is published.

- [x] PR has been tested
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZzijnW3BFnyKoy8tKuQ9r)_