### PR TITLE
fix(openhab): download zip at install time instead of embedding it

### DIFF
--- a/automatic/openhab/openhab.nuspec
+++ b/automatic/openhab/openhab.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>openhab</id>
-    <version>5.2.0</version>
+    <version>0.0</version>
     <title>openHAB</title>
     <authors>openHAB Community and the openHAB Foundation</authors>
     <owners>tunisiano</owners>

--- a/automatic/openhab/tools/chocolateyinstall.ps1
+++ b/automatic/openhab/tools/chocolateyinstall.ps1
@@ -20,11 +20,13 @@ if (!($env:JAVA_HOME)) {
 
 $packageArgs = @{
   packageName    = $packageName
-  Destination    = $toolsDir
-  FileFullPath   = "$toolsDir\openhab-$env:ChocolateyPackageVersion.zip"
+  unzipLocation  = $toolsDir
+  url            = 'https://github.com/openhab/openhab-distro/releases/download/5.2.0/openhab-5.2.0.zip'
+  checksum       = '24B686A6948753E689A140F20B1F40F10BFD9B1CB7417E2FC884154DDB15A9CE'
+  checksumType   = 'sha256'
 }
 
-Get-ChocolateyUnzip @packageArgs
+Install-ChocolateyZipPackage @packageArgs
 
 New-Item "$toolsDir\openHAB" -type directory -force -ErrorAction SilentlyContinue
 Install-ChocolateyShortcut -shortcutFilePath "$env:Public\Desktop\$ShortcutName" -targetPath "$toolsDir\openHAB" -WorkingDirectory "$toolsDir\openHAB" -IconLocation "$toolsDir\openHAB.ico"
@@ -40,4 +42,3 @@ Install-ChocolateyShortcut -shortcutFilePath "$toolsDir\openHAB\$ShortcutName7" 
 
 $WhoAmI=whoami
 icacls.exe $toolsDir /grant $WhoAmI":"'(OI)(CI)'F /T | out-null
-Remove-Item $toolsDir\openhab-*.zip -Force | Out-Null

--- a/automatic/openhab/update.ps1
+++ b/automatic/openhab/update.ps1
@@ -7,6 +7,11 @@ $Owner = $releases.Split('/') | Select-Object -Last 1 -Skip 3
 $repo = $releases.Split('/') | Select-Object -Last 1 -Skip 2
 function global:au_SearchReplace {
 	@{
+		"tools\chocolateyinstall.ps1" = @{
+			"(?i)(url\s*=\s*')[^']*"          = "`${1}$($Latest.URL32)"
+			"(?i)(checksum\s*=\s*')[^']*"     = "`${1}$($Latest.Checksum32)"
+			"(?i)(checksumType\s*=\s*')[^']*" = "`${1}$($Latest.ChecksumType32)"
+		}
 		"legal\VERIFICATION.txt"      = @{
 			"(?i)(x86:).*"        				= "`${1} $($Latest.URL32)"
 			"(?i)(checksum:).*" 				= "`${1} $($Latest.Checksum32)"
@@ -21,10 +26,9 @@ function global:au_AfterUpdate($Package) {
 
 function global:au_GetLatest {
 	$tags = Get-GitHubRelease -OwnerName $Owner -RepositoryName $repo -Latest
-	$url32 = $tags.assets.browser_download_url | Where-Object {$_ -match ".zip$"}
+	$url32 = ($tags.assets.browser_download_url | Where-Object {$_ -match "/openhab-\d[\d.]*\.zip$"}) | Select-Object -First 1
 	. ..\..\scripts\Get-FileVersion.ps1
-	$FileVersion = Get-FileVersion $url32 -keep
-	Move-Item $FileVersion.TempFile -Destination "tools\$($FileVersion.FileName)"
+	$FileVersion = Get-FileVersion $url32
 	$version = $tags.tag_name.Replace('v','').Replace('.M','-M')
 	Update-Metadata -key "releaseNotes" -value $tags.html_url
 	Update-Metadata -key "licenseUrl" -value $((Get-GitHubLicense -OwnerName $Owner -RepositoryName $repo).download_url)


### PR DESCRIPTION
## Problème

Le test choco-bot pour `openhab` 5.2.0 échouait avec :

```
ERROR: The system cannot find the file specified.
C:\ProgramData\chocolatey\lib\openhab\tools\openhab-5.2.0.zip
7z exit code: 2
```

Ref : https://gist.github.com/choco-bot/fa81a0302e758e5bef78eed11fcb5dfc

Le script `chocolateyinstall.ps1` appelait `Get-ChocolateyUnzip` en supposant que le zip openHAB (~290 MB) était embarqué dans le nupkg. Ce zip n'était pas présent dans le package publié.

## Causes identifiées

1. **Zip absent du package** : `Get-FileVersion -keep` + `Move-Item` était censé embarquer le zip, mais le fichier n'atteignait pas le nupkg final publié sur chocolatey.org.
2. **Filtre d'URL incorrect** : `Where-Object {$_ -match ".zip$"}` retourne **deux** zips depuis la release GitHub (`openhab-5.2.0.zip` + `openhab-addons-5.2.0.zip`), ce qui causait un comportement indéfini dans `Get-FileVersion`.

## Corrections

### `tools/chocolateyinstall.ps1`
- Remplacement de `Get-ChocolateyUnzip` (zip embarqué) par `Install-ChocolateyZipPackage` (téléchargement à l'installation depuis GitHub)
- Suppression du nettoyage post-install `Remove-Item openhab-*.zip` (plus nécessaire)

### `update.ps1`
- Ajout de `au_SearchReplace` pour `chocolateyinstall.ps1` (URL + checksum mis à jour automatiquement à chaque bump de version)
- Correction du filtre : `/openhab-\d[\d.]*\.zip$` sélectionne uniquement la distribution principale, pas les addons
- Suppression du `-keep` et du `Move-Item` (le zip n'est plus embarqué)

### `openhab.nuspec`
- Version passée à `0.0` pour forcer AU à re-publier la version 5.2.0 avec le script corrigé

## Test plan

- [ ] Vérifier que `Install-ChocolateyZipPackage` télécharge et extrait bien le zip openHAB
- [ ] Vérifier que `au_SearchReplace` met à jour l'URL et le checksum dans `chocolateyinstall.ps1` lors du prochain bump AU

https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_