### PR TITLE
fix(nteract.install): add exit code 1 to validExitCodes, reset to 0.0

### DIFF
--- a/automatic/nteract.install/nteract.install.nuspec
+++ b/automatic/nteract.install/nteract.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>nteract.install</id>
-    <version>2.6.2</version>
+    <version>0.0</version>
     <title>nteract (Install)</title>
     <authors>nteract contributors</authors>
     <owners>tunisiano</owners>

--- a/automatic/nteract.install/tools/chocolateyInstall.ps1
+++ b/automatic/nteract.install/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 
 $packageName  = $env:ChocolateyPackageName
 $url          = 'https://github.com/nteract/nteract/releases/download/v2.6.2-stable.202606300322/nteract-stable-windows-x64.exe'
@@ -19,7 +19,7 @@ $packageArgs = @{
   checksumType  = $checksumType
 
   silentArgs   = '/S' # NSIS
-  validExitCodes= @(0, 2)
+  validExitCodes= @(0, 1, 2)
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
## Summary

- Add NSIS exit code `1` to `validExitCodes` in `chocolateyInstall.ps1` — the silent installer (`/S`) was returning exit code 1, causing Chocolatey to treat a successful install as a failure.
- Reset nuspec `<version>` to `0.0` so AU re-submits the package on the next run (`-NoCheckChocoVersion` already present in `update.ps1`).

## Changes

| File | Change |
|---|---|
| `nteract.install.nuspec` | `<version>` set to `0.0` |
| `tools/chocolateyInstall.ps1` | `validExitCodes` changed from `@(0, 2)` to `@(0, 1, 2)` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_