### PR TITLE
fix(install4j.install): add -NoCheckChocoVersion, reset to 0.0

### DIFF
--- a/automatic/install4j.install/install4j.install.nuspec
+++ b/automatic/install4j.install/install4j.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>install4j.install</id>
-    <version>13.0.2</version>
+    <version>0.0</version>
     <title>install4j (Install)</title>
     <authors>Dr Ingo Kegel</authors>
     <owners>tunisiano</owners>

--- a/automatic/install4j.install/update.ps1
+++ b/automatic/install4j.install/update.ps1
@@ -34,4 +34,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32
+update -ChecksumFor 32 -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

- Add `-NoCheckChocoVersion` to `update -ChecksumFor 32` in `update.ps1` so AU can re-push the package regardless of the version already published on chocolatey.org.
- Reset nuspec `<version>` to `0.0` so AU detects the package as needing an update and recomputes the checksum from the upstream CDN URL.

## Changes

| File | Change |
|---|---|
| `install4j.install.nuspec` | `<version>` set to `0.0` |
| `update.ps1` | `update -ChecksumFor 32` → `update -ChecksumFor 32 -NoCheckChocoVersion` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_