### PR TITLE
fix(soundvolumeview): switch to download-at-install-time, reset to 0.0

### DIFF
--- a/automatic/soundvolumeview/soundvolumeview.nuspec
+++ b/automatic/soundvolumeview/soundvolumeview.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>soundvolumeview</id>
-    <version>2.53</version>
+    <version>0.0</version>
     <title>SoundVolumeView</title>
     <authors>Nir Sofer</authors>
     <owners>tunisiano</owners>

--- a/automatic/soundvolumeview/tools/chocolateyInstall.ps1
+++ b/automatic/soundvolumeview/tools/chocolateyInstall.ps1
@@ -1,18 +1,20 @@
 $ErrorActionPreference = 'Stop'
-$toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$file32         = "$(Join-Path $toolsDir -ChildPath 'soundvolumeview.zip')"
-$file64         = "$(Join-Path $toolsDir -ChildPath 'soundvolumeview-x64.zip')"
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$unzipArgs = @{
-    PackageName     = $env:ChocolateyPackageName
-    FileFullPath    = $file32
-    FileFullPath64  = $file64
-    Destination     = $toolsDir
+$packageArgs = @{
+    packageName    = $env:ChocolateyPackageName
+    unzipLocation  = $toolsDir
+    url            = 'https://www.nirsoft.net/utils/soundvolumeview.zip'
+    checksum       = '93064FBBDB8D3B42B9F5FCFB80C1ED8C17A21C207869052940683607E889054B'
+    checksumType   = 'sha256'
+    url64bit       = 'https://www.nirsoft.net/utils/soundvolumeview-x64.zip'
+    checksum64     = 'EE2C45553FB9FB31B71DB88B537C18E25C1A387A4A9009D081BDB38265C68E1F'
+    checksumType64 = 'sha256'
 }
 
-Get-ChocolateyUnzip @unzipArgs
+Install-ChocolateyZipPackage @packageArgs
 
-$installFile    = (get-childitem -Filter "*.exe" -Recurse).FullName
+$installFile = (Get-ChildItem -Path $toolsDir -Filter '*.exe' -Recurse).FullName
 
 Set-Content -Path ("$installFile.gui") `
             -Value $null

--- a/automatic/soundvolumeview/update.ps1
+++ b/automatic/soundvolumeview/update.ps1
@@ -3,6 +3,14 @@ import-module chocolatey-AU
 
 function global:au_SearchReplace {
 	@{
+		"tools/chocolateyInstall.ps1" = @{
+			"(?i)(url\s*=\s*')[^']*"             = "`${1}$($Latest.URL32)"
+			"(?i)(checksum\s*=\s*')[^']*"        = "`${1}$($Latest.Checksum32)"
+			"(?i)(checksumType\s*=\s*')[^']*"    = "`${1}$($Latest.ChecksumType32)"
+			"(?i)(url64bit\s*=\s*')[^']*"        = "`${1}$($Latest.URL64)"
+			"(?i)(checksum64\s*=\s*')[^']*"      = "`${1}$($Latest.Checksum64)"
+			"(?i)(checksumType64\s*=\s*')[^']*"  = "`${1}$($Latest.ChecksumType64)"
+		}
 		"legal\VERIFICATION.txt"      = @{
 			"(?i)(x86:).*"        				= "`${1} $($Latest.URL32)"
 			"(?i)(checksum:).*" 				= "`${1} $($Latest.Checksum32)"


### PR DESCRIPTION
## Summary

- Replace `Get-ChocolateyUnzip` (embedded zip approach) with `Install-ChocolateyZipPackage` in `chocolateyInstall.ps1` — the embedded zip files were not present in the published nupkg, causing every install to fail with "file not found".
- Add `tools/chocolateyInstall.ps1` to `au_SearchReplace` in `update.ps1` so AU keeps the URLs and checksums in `chocolateyInstall.ps1` up to date on each version bump.
- Reset nuspec `<version>` to `0.0` so AU re-submits the corrected package (`-NoCheckChocoVersion` already present).

## Changes

| File | Change |
|---|---|
| `soundvolumeview.nuspec` | `<version>` set to `0.0` |
| `tools/chocolateyInstall.ps1` | Switch from `Get-ChocolateyUnzip` (local files) to `Install-ChocolateyZipPackage` (download from NirSoft) |
| `update.ps1` | Add `chocolateyInstall.ps1` block to `au_SearchReplace` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_