### PR TITLE
ci: add workflow to auto-remove -NoCheckChocoVersion after AU re-push

### DIFF
--- a/.github/workflows/cleanup-nocheckchoco.yml
+++ b/.github/workflows/cleanup-nocheckchoco.yml
@@ -1,0 +1,79 @@
+name: Remove -NoCheckChocoVersion after AU re-push
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Find and fix packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for update_file in automatic/*/update.ps1; do
+            # Skip if no -NoCheckChocoVersion flag
+            if ! grep -q '\-NoCheckChocoVersion' "$update_file"; then
+              continue
+            fi
+
+            pkg=$(basename "$(dirname "$update_file")")
+
+            # Find the nuspec (name may differ from folder name)
+            nuspec=$(find "automatic/$pkg" -maxdepth 1 -name '*.nuspec' | head -1)
+            if [ -z "$nuspec" ]; then
+              echo "No nuspec found for $pkg, skipping"
+              continue
+            fi
+
+            version=$(grep -oP '(?<=<version>)[^<]+' "$nuspec" | head -1)
+
+            # Only act if version has moved past 0.0
+            if [ "$version" = "0.0" ]; then
+              continue
+            fi
+
+            echo "Package $pkg is at version $version — removing -NoCheckChocoVersion"
+
+            branch="auto/remove-nocheckchoco-$pkg"
+
+            # Skip if an open PR already targets this branch
+            existing=$(gh pr list --head "$branch" --state open --json number -q '.[0].number' 2>/dev/null)
+            if [ -n "$existing" ]; then
+              echo "Open PR #$existing already exists for $pkg, skipping"
+              continue
+            fi
+
+            git checkout -B "$branch" origin/master
+
+            # Remove the flag (handles flag anywhere on the update line)
+            sed -i 's/ -NoCheckChocoVersion//g' "$update_file"
+
+            git add "$update_file"
+            git commit -m "chore($pkg): remove -NoCheckChocoVersion (version now $version)"
+            git push -u origin "$branch" --force-with-lease
+
+            gh pr create \
+              --title "chore($pkg): remove -NoCheckChocoVersion (version now $version)" \
+              --body "AU has successfully re-pushed \`$pkg\` and the nuspec version is now \`$version\` (no longer \`0.0\`). This removes the one-time \`-NoCheckChocoVersion\` flag per the package maintenance policy." \
+              --base master \
+              --head "$branch"
+
+            git checkout master
+          done


### PR DESCRIPTION
## Summary\n\nAdds `.github/workflows/cleanup-nocheckchoco.yml`, a daily scheduled workflow that:\n\n1. Scans all `automatic/*/update.ps1` files for `-NoCheckChocoVersion`\n2. Reads the corresponding `.nuspec` version\n3. If the version is no longer `0.0` (AU has already successfully re-pushed the package), creates a branch and opens a PR to remove the flag\n4. **Skips** packages that already have an open PR targeting the same branch (`auto/remove-nocheckchoco-<pkg>`)\n\n## Behaviour\n\n- Runs daily at 10:00 UTC and on `workflow_dispatch`\n- One PR per package (never batched)\n- Idempotent: re-running when a PR is already open does nothing\n- Branch naming: `auto/remove-nocheckchoco-<package-name>`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_