### PR TITLE
chore(install4j.install): remove -NoCheckChocoVersion after re-push to 13.0.2

### DIFF
--- a/automatic/install4j.install/update.ps1
+++ b/automatic/install4j.install/update.ps1
@@ -34,4 +34,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
AU successfully re-pushed `install4j.install` 13.0.2 to chocolatey.org and it was accepted. Removing the one-time `-NoCheckChocoVersion` flag from `update.ps1` so normal AU version-checking resumes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_