### PR TITLE
chore(cleanup-nocheckchoco): limit to 10 PRs per run

### DIFF
--- a/.github/workflows/cleanup-nocheckchoco.yml
+++ b/.github/workflows/cleanup-nocheckchoco.yml
@@ -27,10 +27,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          existing_count=$(gh pr list --search 'head:auto/remove-nocheckchoco-' --state open --json number -q 'length' 2>/dev/null || echo 0)
+          echo "Currently $existing_count open cleanup PRs"
+          slots=$((10 - existing_count))
+          if [ "$slots" -le 0 ]; then
+            echo "Already at or above 10 open cleanup PRs, skipping"
+            exit 0
+          fi
           pr_count=0
           for update_file in automatic/*/update.ps1; do
-            if [ "$pr_count" -ge 10 ]; then
-              echo "Reached limit of 10 PRs for this run, stopping"
+            if [ "$pr_count" -ge "$slots" ]; then
+              echo "Reached the open-PR limit of 10, stopping"
               break
             fi
 

--- a/.github/workflows/cleanup-nocheckchoco.yml
+++ b/.github/workflows/cleanup-nocheckchoco.yml
@@ -27,7 +27,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          pr_count=0
           for update_file in automatic/*/update.ps1; do
+            if [ "$pr_count" -ge 10 ]; then
+              echo "Reached limit of 10 PRs for this run, stopping"
+              break
+            fi
+
             # Skip if no -NoCheckChocoVersion flag
             if ! grep -q '\-NoCheckChocoVersion' "$update_file"; then
               continue
@@ -76,4 +82,5 @@ jobs:
               --head "$branch"
 
             git checkout master
+            pr_count=$((pr_count + 1))
           done


### PR DESCRIPTION
Adds a counter to the cleanup workflow so it stops after creating 10 PRs per run. The daily schedule means all packages will be covered over successive days without flooding the PR list at once.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_