### PR TITLE
chore(cleanup-nocheckchoco): cap at 10 total open PRs in the repo

### DIFF
--- a/.github/workflows/cleanup-nocheckchoco.yml
+++ b/.github/workflows/cleanup-nocheckchoco.yml
@@ -27,11 +27,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          existing_count=$(gh pr list --search 'head:auto/remove-nocheckchoco-' --state open --json number -q 'length' 2>/dev/null || echo 0)
-          echo "Currently $existing_count open cleanup PRs"
+          existing_count=$(gh pr list --state open --json number -q 'length' 2>/dev/null || echo 0)
+          echo "Currently $existing_count open PRs total"
           slots=$((10 - existing_count))
           if [ "$slots" -le 0 ]; then
-            echo "Already at or above 10 open cleanup PRs, skipping"
+            echo "Already at or above 10 open PRs, skipping"
             exit 0
           fi
           pr_count=0


### PR DESCRIPTION
Updates the cleanup workflow to count **all** open PRs in the repo (not just the cleanup ones) when deciding how many new PRs to open. If there are already 10 or more open PRs of any kind, the workflow skips entirely. Otherwise it fills only the remaining slots up to 10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_