### PR TITLE
chore(cleanup-nocheckchoco): add [skip ci] to cleanup commits

### DIFF
--- a/.github/workflows/cleanup-nocheckchoco.yml
+++ b/.github/workflows/cleanup-nocheckchoco.yml
@@ -79,7 +79,7 @@ jobs:
             sed -i 's/ -NoCheckChocoVersion//g' "$update_file"
 
             git add "$update_file"
-            git commit -m "chore($pkg): remove -NoCheckChocoVersion (version now $version)"
+            git commit -m "chore($pkg): remove -NoCheckChocoVersion (version now $version) [skip ci]"
             git push -u origin "$branch" --force-with-lease
 
             gh pr create \


### PR DESCRIPTION
Adds `[skip ci]` to the commit message of each cleanup commit so GitHub Actions doesn't trigger a full CI run for these trivial one-line changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_