### PR TITLE
chore(au): remove GitLab integration

### DIFF
--- a/au/update_all.ps1
+++ b/au/update_all.ps1
@@ -53,13 +53,7 @@ $Options = [ordered]@{
         Password = $Env:github_api_key
     }
 
-    GitLab = @{
-        User			= 'tunisiano187'					#Git username, leave empty if github api key is used
-        API_Key			= $env:Gitlab_api_key					#Password if username is not empty, otherwise api key
-		PushURL			= $env:Gitlab_PushURL
-		Force			= $True
-		commitStrategy	= 'atomic'
-    }
+
     #Issues = @{
     #    ApiToken    = $Env:github_api_key                   #Your github api key
     #    BaseBranch  = "master"

--- a/au/update_vars.ps1
+++ b/au/update_vars.ps1
@@ -23,15 +23,3 @@ if(!(Test-Path Env:github_api_key)) {
 }
 $Env:au_Push                    = 'true'                    # Push to chocolatey
 
-if(!(Test-Path Env:gitlab_user)) {
-    $Env:gitlab_user            = $GITLAB_USER_LOGIN        # GitLab username to use for the push
-}
-if(!(Test-Path Env:gitlab_api_key)) {
-    $Env:gitlab_api_key         = $Gitlab_api               # GitLab API key associated with gitlab_user
-}
-if(!(Test-Path Env:gitlab_push_url)) {
-    $Env:gitlab_push_url        = $Gitlab_PushURL           # GitLab URL to push to. Must be HTTP or HTTPS. e.g. https://git.example.org/jekotia/au.git
-}
-if(!(Test-Path Env:gitlab_commit_strategy)) {
-    $Env:gitlab_commit_strategy = 'atomictag'               # Same values as the Git plugin; single, atomic, or atomictag
-}


### PR DESCRIPTION
Removes the GitLab push configuration from `au/update_all.ps1` and the GitLab environment variable setup from `au/update_vars.ps1`. GitLab is no longer used for this repository.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCakkjVmP2wXnsaE7oEEfo)_