### PR TITLE
fix(faceit): force AU resubmit to fix stale checksum on rolling URL

### DIFF
--- a/automatic/faceit/Faceit.nuspec
+++ b/automatic/faceit/Faceit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>faceit</id>
-    <version>2.8.5</version>
+    <version>0.0</version>
     <title>Faceit</title>
     <authors>Faceit</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
Fixes chocolatey.org verification failure for `faceit`

Proposed changes in this pull request:
- Reset `automatic/faceit/Faceit.nuspec` version from `2.8.5` to `0.0`

## Why

chocolatey.org's automated verifier just failed `faceit` v2.8.5 install testing (https://gist.github.com/choco-bot/8fe3558aa92eed50f49a0e88dd8af1b6):

```
ERROR: Checksum for '...\FACEIT-setup-latest.exe' did not meet 'ee2d9eee181fe023ff167f2cae49bc365bed29e9c949280b5f50a33d72399da9' for checksum type 'sha256'.
```

`faceit`'s install URL (`https://faceit-client.faceit-cdn.net/release/FACEIT-setup-latest.exe`) is a rolling "latest" pointer. The upstream file changed again after AU last computed and committed the checksum for v2.8.5, so the currently-pushed package is broken for anyone installing it.

`update.ps1` already carries `-NoCheckChocoVersion` (`update -ChecksumFor 32 -NoCheckChocoVersion`) from an earlier fix, and `au_GetLatest` currently returns the same version (2.8.5) as the nuspec, so AU treats the package as "no updates" and never re-downloads or re-pushes. Resetting the nuspec version to `0.0` forces AU's next run to detect a version change, re-download the installer, recompute a fresh checksum via `-ChecksumFor 32`, and re-push despite v2.8.5 already existing on chocolatey.org.

Closed #4232, which proposed removing `-NoCheckChocoVersion` on the (incorrect) assumption that the prior resubmit had already succeeded — it hadn't; it just hadn't failed verification yet at the time that PR was opened.

- [x] PR as been tested (nuspec version format validated; AU update flow logic verified against `au/update_all.ps1` conventions and matching prior fixes in this repo)
- [x] Single-package change only
- [x] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_