### PR TITLE
chore(nteract.install): remove -NoCheckChocoVersion (version now 2.6.2)

### DIFF
--- a/automatic/nteract.install/update.ps1
+++ b/automatic/nteract.install/update.ps1
@@ -43,4 +43,4 @@ function global:au_GetLatest {
     return @{ URL32 = $url32; Version = $version }
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes N/A

Proposed changes in this pull request:
- Remove the one-time `-NoCheckChocoVersion` flag from `automatic/nteract.install/update.ps1`

## Why

AU has successfully re-pushed `nteract.install` after the exit-code-1 install fix (#4126, `validExitCodes` now includes `1`) and the nuspec version is now `2.6.2` (no longer `0.0`). Per the package maintenance policy in CLAUDE.md, the one-time re-push flag should be removed now that AU has picked up the fix — it's not a permanent setting.

- [x] PR as been tested (single-line diff, matches the pattern already used by PRs #4224-#4233)
- [x] Single-package change only
- [x] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_