### PR TITLE
fix(freeplane): fail loudly on installer download failure, force AU resubmit

### DIFF
--- a/automatic/freeplane/freeplane.nuspec
+++ b/automatic/freeplane/freeplane.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>freeplane</id>
     <title>Freeplane</title>
-    <version>1.13.3</version>
+    <version>0.0</version>
     <authors>Dimitry Polivaev,Volker Borchers</authors>
     <owners>tunisiano</owners>
     <licenseUrl>https://github.com/freeplane/freeplane/blob/1.11.x/license.txt</licenseUrl>

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -1,3 +1,4 @@
+$ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 Import-Module ..\..\scripts\au_extensions.psm1
 
@@ -60,4 +61,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
Fixes N/A

Proposed changes in this pull request:
- Add `$ErrorActionPreference = 'Stop'` to `automatic/freeplane/update.ps1`
- Reset `automatic/freeplane/freeplane.nuspec` version to `0.0` and add `-NoCheckChocoVersion` to force an AU resubmit

## Why

chocolatey.org's automated verifier failed Freeplane v1.13.3 install testing (https://gist.github.com/choco-bot/64bc72d818bfa0f1e2fe2d249251389b):

```
ERROR: This package does not support architecture.
Running Install-ChocolateyPackage -packageName 'FreePlane' ... -file '' -validExitCodes '0'
```

`chocolateyInstall.ps1` locates the installer dynamically via `Get-Item $toolsPath\*.exe`, so an empty `-file` means the published nupkg shipped with **no installer at all**.

Root cause: `au_BeforeUpdate` downloads the installer with `Invoke-WebRequest -OutFile $destPath` (no `-ErrorAction Stop`), and the script never sets `$ErrorActionPreference`. A failed download (e.g. a SourceForge hiccup) is therefore a non-terminating error — execution continued past it, `Get-FileHash` on the now-missing file also failed non-terminating, and the AU run went on to pack and push a nupkg with an empty `tools\` directory. Since the upstream version didn't change, AU has no way to detect this and retry on its own; the package (v1.13.3) shipped broken.

Adding `$ErrorActionPreference = 'Stop'` makes any future download failure abort the run loudly instead of silently publishing a broken package — matching the pattern already used in other packages in this repo (e.g. `Executor`). The nuspec is reset to `0.0` with `-NoCheckChocoVersion` to force the next AU run to redo the download/pack/push, since the version itself isn't changing.

- [x] PR as been tested (traced the exact non-terminating-error path through `au_BeforeUpdate` against the observed empty-`-file` failure; confirmed no `.exe` is currently tracked in `tools/` and that `chocolateyInstall.ps1` depends on one being present at pack time)
- [x] Single-package change only
- [x] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_