### PR TITLE
fix(install4j.install): sync nuspec version with what's actually approved (13.0.2)

### DIFF
--- a/automatic/install4j.install/install4j.install.nuspec
+++ b/automatic/install4j.install/install4j.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>install4j.install</id>
-    <version>0.0</version>
+    <version>13.0.2</version>
     <title>install4j (Install)</title>
     <authors>Dr Ingo Kegel</authors>
     <owners>tunisiano</owners>


### PR DESCRIPTION
Fixes N/A

Proposed changes in this pull request:
- Update `automatic/install4j.install/install4j.install.nuspec` version from `0.0` to `13.0.2`

## Why

PR #4132 removed `-NoCheckChocoVersion` from `update.ps1` on the assumption that AU's re-push to 13.0.2 had already succeeded, but never bumped the nuspec `<version>` itself back up from the `0.0` placeholder set by #4127.

Checked live on chocolatey.org: `install4j.install` 13.0.2 has been **"Approved" (trusted package) since 17 Jul 2026**, all 3 checks passing (validation, verification, virus scan), and `tools/chocolateyInstall.ps1` in this repo already has the correct 13.0.2 URL/checksum committed. Only the nuspec version tag was stale at `0.0` — this PR just syncs it with reality so AU's version-diff logic isn't perpetually confused about whether this package needs an update.

(Separately: the meta `install4j` package's old `13.0.0` submission was rejected by chocolatey.org on 29 Jul after 15 days of failed verification — this is dead history predating the fixed rolling-checksum handling, not something that needs further action; the meta package is already at 13.0.2 locally, matching its dependency pin.)

- [x] PR as been tested (verified live chocolatey.org status for install4j.install 13.0.2 via direct page scrape; confirmed committed `chocolateyInstall.ps1` content already matches the approved package exactly)
- [x] Single-package change only
- [x] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_