### PR TITLE
fix(Executor): add -NoCheckChocoVersion to force re-push of 2.3.9

### DIFF
--- a/automatic/Executor/update.ps1
+++ b/automatic/Executor/update.ps1
@@ -49,4 +49,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor 32 -NoCheckUrl
+update -ChecksumFor 32 -NoCheckUrl -NoCheckChocoVersion


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Add `-NoCheckChocoVersion` to `update.ps1` so AU re-submits version 2.3.9 to Chocolatey.org
- Nuspec is already at `0.0`, so AU will detect a version change and trigger the push
- Package is currently **Waiting for Maintainer** on Chocolatey.org due to a checksum mismatch (the binary at executor.dk changed silently); this forces a re-download with fresh checksums

- [ ] PR has been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_