### PR TITLE
fix(freeplane): add -NoCheckChocoVersion and reset to 0.0 to force re-push

### DIFF
--- a/automatic/freeplane/freeplane.nuspec
+++ b/automatic/freeplane/freeplane.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>freeplane</id>
     <title>Freeplane</title>
-    <version>1.13.3</version>
+    <version>0.0</version>
     <authors>Dimitry Polivaev,Volker Borchers</authors>
     <owners>tunisiano</owners>
     <licenseUrl>https://github.com/freeplane/freeplane/blob/1.11.x/license.txt</licenseUrl>

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -61,4 +61,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Reset nuspec version to `0.0` so AU detects a version change and triggers a re-push
- Add `-NoCheckChocoVersion` to `update.ps1` to bypass the version-already-exists guard on Chocolatey.org
- Package 1.13.3 is currently **Waiting for Maintainer** on Chocolatey.org; this forces AU to re-download, re-embed the installer, and re-submit

- [ ] PR has been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_