### PR TITLE
chore(soundvolumeview): remove -NoCheckChocoVersion (version now 2.53)

### DIFF
--- a/automatic/soundvolumeview/update.ps1
+++ b/automatic/soundvolumeview/update.ps1
@@ -43,4 +43,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -NoCheckChocoVersion -ChecksumFor none
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1`
- AU successfully re-pushed the fixed package (version 2.53 is now in the nuspec)
- The flag was a one-time re-push mechanism and has served its purpose

- [ ] PR has been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/tunisiano187/chocolatey-ps-validator/blob/master/.github/CONTRIBUTING.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_