### PR TITLE
revert(Executor): remove -NoCheckChocoVersion re-added by #4262

### DIFF
--- a/automatic/Executor/update.ps1
+++ b/automatic/Executor/update.ps1
@@ -49,4 +49,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor 32 -NoCheckUrl -NoCheckChocoVersion
+update -ChecksumFor 32 -NoCheckUrl


### PR DESCRIPTION
Fixes N/A

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `automatic/Executor/update.ps1` (back to `update -ChecksumFor 32 -NoCheckUrl`)

## Why

PR #4262 (merged today, from a different concurrent session) re-added `-NoCheckChocoVersion`, reintroducing the exact bug diagnosed and fixed by #4236 earlier today: this flag disables AU's pre-push check for whether a version already exists on chocolatey.org. `Executor 2.3.10` is already **"Approved" and live** (confirmed via direct page check). With the nuspec at `0.0` and `-NoCheckChocoVersion` back in place, the next scheduled AU run will treat this as "needs a push", skip the existence check, and hit the same `409 Conflict` that #4236's investigation found:

```
Chocolatey v2.7.3 Attempting to push Executor.2.3.10.nupkg to https://push.chocolatey.org
An error has occurred... Response status code does not indicate success: 409 (Conflict).
```

The rolling-checksum problem #4262 was actually trying to address (the `executor.dk/ExecutorSetup.exe` binary changing without a version bump) is already handled by `au_BeforeUpdate` calling `Get-RemoteChecksum` fresh on every run — also from #4236. No flag is needed for that; removing the flag here doesn't reintroduce the checksum-staleness issue.

- [x] PR as been tested (confirmed live chocolatey.org status for Executor 2.3.10 via direct page scrape; traced exact 409 failure mode back to PR #4236's own diagnosis)
- [x] Single-package change only
- [x] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_