### PR TITLE
chore(ofview): remove -NoCheckChocoVersion (version now 1.91.0)

### DIFF
--- a/automatic/ofview/update.ps1
+++ b/automatic/ofview/update.ps1
@@ -38,4 +38,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -NoCheckUrl -ChecksumFor none -NoCheckChocoVersion
+update -NoCheckUrl -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for ofview — flag has served its purpose now that the package is at version 1.91.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_