### PR TITLE
chore(orangec): remove -NoCheckChocoVersion (version now 7.10.1)

### DIFF
--- a/automatic/orangec/update.ps1
+++ b/automatic/orangec/update.ps1
@@ -44,4 +44,4 @@ function global:au_GetLatest {
     return @{ URL32 = $url32; Version = $version; ReleaseUri = $tags.html_url }
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for orangec — flag has served its purpose now that the package is at version 7.10.1 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_