### PR TITLE
chore(ossec-client): remove -NoCheckChocoVersion (version now 4.1.0)

### DIFF
--- a/automatic/ossec-client/update.ps1
+++ b/automatic/ossec-client/update.ps1
@@ -27,4 +27,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for ossec-client — flag has served its purpose now that the package is at version 4.1.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_