### PR TITLE
chore(ost2): remove -NoCheckChocoVersion (version now 2.30.0042)

### DIFF
--- a/automatic/ost2/update.ps1
+++ b/automatic/ost2/update.ps1
@@ -39,4 +39,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -NoCheckUrl -NoCheckChocoVersion -ChecksumFor none
+update -NoCheckUrl -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for ost2 — flag has served its purpose now that the package is at version 2.30.0042 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_