### PR TITLE
chore(p4merge): remove -NoCheckChocoVersion (version now 2026.2)

### DIFF
--- a/automatic/p4merge/update.ps1
+++ b/automatic/p4merge/update.ps1
@@ -58,4 +58,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for p4merge — flag has served its purpose now that the package is at version 2026.2 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_