### PR TITLE
chore(par2cmdline): remove -NoCheckChocoVersion (version now 1.2.0)

### DIFF
--- a/automatic/par2cmdline/update.ps1
+++ b/automatic/par2cmdline/update.ps1
@@ -53,4 +53,4 @@ function global:au_GetLatest {
     return @{ URL32 = $url32; URL64 = $url64; Version = $version }
 }
 
-update -NoCheckChocoVersion
+update


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for par2cmdline — flag has served its purpose now that the package is at version 1.2.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_