### PR TITLE
chore(paraview): remove -NoCheckChocoVersion (version now 6.1.1)

### DIFF
--- a/automatic/paraview/update.ps1
+++ b/automatic/paraview/update.ps1
@@ -56,4 +56,4 @@ function global:au_GetLatest {
 	return @{ URL32 = $url; Version = $version }
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for paraview — flag has served its purpose now that the package is at version 6.1.1 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_