### PR TITLE
chore(pestudio): remove -NoCheckChocoVersion (version now 9.61.0.0)

### DIFF
--- a/automatic/pestudio/update.ps1
+++ b/automatic/pestudio/update.ps1
@@ -37,4 +37,4 @@ function global:au_BeforeUpdate {
     $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType32 # You can omit the algorithm, the function will use sha256 by default
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for pestudio — flag has served its purpose now that the package is at version 9.61.0.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_