### PR TITLE
chore(pinode): remove -NoCheckChocoVersion (version now 0.5.4)

### DIFF
--- a/automatic/pinode/update.ps1
+++ b/automatic/pinode/update.ps1
@@ -33,4 +33,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for pinode — flag has served its purpose now that the package is at version 0.5.4 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_