### PR TITLE
chore(pngquant): remove -NoCheckChocoVersion (version now 2.17.0)

### DIFF
--- a/automatic/pngquant/update.ps1
+++ b/automatic/pngquant/update.ps1
@@ -52,4 +52,4 @@ function global:au_GetLatest {
     @{ URL32 = $url32; Version = $version }
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for pngquant — flag has served its purpose now that the package is at version 2.17.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_