### PR TITLE
chore(powderplayer): remove -NoCheckChocoVersion (version now 1.60)

### DIFF
--- a/automatic/powderplayer/update.ps1
+++ b/automatic/powderplayer/update.ps1
@@ -33,4 +33,4 @@ function global:au_GetLatest {
     return @{ URL32 = $url32; Version = $version }
 }
 
-update-package -ChecksumFor 32 -NoCheckChocoVersion
+update-package -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for powderplayer — flag has served its purpose now that the package is at version 1.60 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_