### PR TITLE
chore(projectlibre.install): remove -NoCheckChocoVersion (version now 1.9.8)

### DIFF
--- a/automatic/projectlibre.install/update.ps1
+++ b/automatic/projectlibre.install/update.ps1
@@ -47,4 +47,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for projectlibre.install — flag has served its purpose now that the package is at version 1.9.8 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_