### PR TITLE
chore(quaternion): remove -NoCheckChocoVersion (version now 0.0.97.1)

### DIFF
--- a/automatic/quaternion/update.ps1
+++ b/automatic/quaternion/update.ps1
@@ -36,4 +36,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -NoCheckChocoVersion
+update


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for quaternion — flag has served its purpose now that the package is at version 0.0.97.1 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_