### PR TITLE
chore(sd-card-formatter): remove -NoCheckChocoVersion (version now 5.0.3.2025011901)

### DIFF
--- a/automatic/sd-card-formatter/update.ps1
+++ b/automatic/sd-card-formatter/update.ps1
@@ -42,4 +42,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for sd-card-formatter — flag has served its purpose now that the package is at version 5.0.3.2025011901 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_