### PR TITLE
chore(snort): remove -NoCheckChocoVersion (version now 2.9.20)

### DIFF
--- a/automatic/snort/update.ps1
+++ b/automatic/snort/update.ps1
@@ -36,4 +36,4 @@ function global:au_GetLatest {
     return $Latest
 }
 
-update -ChecksumFor none -NoCheckUrl -NoCheckChocoVersion
+update -ChecksumFor none -NoCheckUrl


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for snort — flag has served its purpose now that the package is at version 2.9.20 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_