### PR TITLE
chore(solarwinds-recovery-console): remove -NoCheckChocoVersion (version now 23.12.0.24080)

### DIFF
--- a/automatic/solarwinds-recovery-console/update.ps1
+++ b/automatic/solarwinds-recovery-console/update.ps1
@@ -31,4 +31,4 @@ function global:au_GetLatest {
     return $Latest
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for solarwinds-recovery-console — flag has served its purpose now that the package is at version 23.12.0.24080 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_