### PR TITLE
chore(sysexp): remove -NoCheckChocoVersion (version now 1.77.0)

### DIFF
--- a/automatic/sysexp/update.ps1
+++ b/automatic/sysexp/update.ps1
@@ -17,4 +17,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none -NoCheckUrl -NoCheckChocoVersion
+update -ChecksumFor none -NoCheckUrl


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for sysexp — flag has served its purpose now that the package is at version 1.77.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_