### PR TITLE
chore(tautulli): remove -NoCheckChocoVersion (version now 2.17.2)

### DIFF
--- a/automatic/tautulli/update.ps1
+++ b/automatic/tautulli/update.ps1
@@ -34,4 +34,4 @@ function global:au_GetLatest {
     return @{ URL32 = $url; Version = $version }
 }
 
-update-package -ChecksumFor 32 -NoCheckChocoVersion
+update-package -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for tautulli — flag has served its purpose now that the package is at version 2.17.2 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_