### PR TITLE
chore(thebrain.install): remove -NoCheckChocoVersion (version now 14.0.116.0)

### DIFF
--- a/automatic/thebrain.install/update.ps1
+++ b/automatic/thebrain.install/update.ps1
@@ -36,4 +36,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for thebrain.install — flag has served its purpose now that the package is at version 14.0.116.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_