### PR TITLE
chore(thebrain): remove -NoCheckChocoVersion (version now 14.0.112)

### DIFF
--- a/automatic/thebrain/update.ps1
+++ b/automatic/thebrain/update.ps1
@@ -17,4 +17,4 @@ function global:au_GetLatest {
     }
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for thebrain — flag has served its purpose now that the package is at version 14.0.112 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_