### PR TITLE
chore(traffic-monitor): remove -NoCheckChocoVersion (version now 1.86)

### DIFF
--- a/automatic/traffic-monitor/update.ps1
+++ b/automatic/traffic-monitor/update.ps1
@@ -54,4 +54,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
- update -NoCheckChocoVersion
+ update


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for traffic-monitor — flag has served its purpose now that the package is at version 1.86 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_