### PR TITLE
chore(trafficlight-firefox): remove -NoCheckChocoVersion (version now 3.4.3)

### DIFF
--- a/automatic/trafficlight-firefox/update.ps1
+++ b/automatic/trafficlight-firefox/update.ps1
@@ -34,4 +34,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for trafficlight-firefox — flag has served its purpose now that the package is at version 3.4.3 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_