### PR TITLE
chore(ubooquity): remove -NoCheckChocoVersion (version now 3.1.0)

### DIFF
--- a/automatic/ubooquity/update.ps1
+++ b/automatic/ubooquity/update.ps1
@@ -33,4 +33,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for ubooquity — flag has served its purpose now that the package is at version 3.1.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_