### PR TITLE
chore(unison): remove -NoCheckChocoVersion (version now 2.54.0)

### DIFF
--- a/automatic/unison/update.ps1
+++ b/automatic/unison/update.ps1
@@ -35,4 +35,4 @@ function global:au_GetLatest {
     return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for unison — flag has served its purpose now that the package is at version 2.54.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_