### PR TITLE
chore(vigembus): remove -NoCheckChocoVersion (version now 1.22.0)

### DIFF
--- a/automatic/vigembus/update.ps1
+++ b/automatic/vigembus/update.ps1
@@ -48,4 +48,4 @@ function global:au_GetLatest {
   }
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for vigembus — flag has served its purpose now that the package is at version 1.22.0 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_