### PR TITLE
chore(wakemeonlan): remove -NoCheckChocoVersion (version now 1.96)

### DIFF
--- a/automatic/wakemeonlan/update.ps1
+++ b/automatic/wakemeonlan/update.ps1
@@ -30,4 +30,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -NoCheckChocoVersion
+update


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for wakemeonlan — flag has served its purpose now that the package is at version 1.96 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_