### PR TITLE
chore(kasperskyfree): remove -NoCheckChocoVersion (version now 21.2.16.590)

### DIFF
--- a/manual/kasperskyfree/update.ps1
+++ b/manual/kasperskyfree/update.ps1
@@ -38,4 +38,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor 32 -NoCheckChocoVersion
+update -ChecksumFor 32


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Remove `-NoCheckChocoVersion` from `update.ps1` for kasperskyfree — flag has served its purpose now that the package is at version 21.2.16.590 on Chocolatey.org

- [ ] PR as been tested
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs
- [ ] Read contribution guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsJYwa8tXukPXgn1HtVmuv)_