### PR TITLE
ci: use chocolatey-au develop branch instead of master

### DIFF
--- a/setup/au_setup.ps1
+++ b/setup/au_setup.ps1
@@ -15,7 +15,7 @@ if ($null -ne $refreshenv -and $refreshenv.CommandType -ne 'Application') {
 
 Install-PackageProvider -Name NuGet -Force
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-$Env:au_version = "master"
+$Env:au_version = "develop"
 
 Write-Output "Build AU"
 git clone -q https://github.com/chocolatey-community/chocolatey-au.git $Env:TEMP/au


### PR DESCRIPTION
## Summary
- Point `setup/au_setup.ps1` (used by the GitLab CI pipeline) at the `develop` branch of [chocolatey-community/chocolatey-au](https://github.com/chocolatey-community/chocolatey-au) instead of `master`, by changing `$Env:au_version`.
- `au_version` is passed to `Install-AU.ps1`, which does `git checkout $Version` on the already-cloned repo — this is the value that actually determines which branch ends up installed, regardless of what the initial `git clone` checks out.

## Test plan
- [ ] Run the GitLab CI pipeline (or `setup/au_setup.ps1` locally) and confirm AU builds from the `develop` branch without errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_