### PR TITLE
fix(freeplane): verify downloaded installer before checksum, reset to 0.0 to force re-push

### DIFF
--- a/automatic/freeplane/freeplane.nuspec
+++ b/automatic/freeplane/freeplane.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>freeplane</id>
     <title>Freeplane</title>
-    <version>1.13.3</version>
+    <version>0.0</version>
     <authors>Dimitry Polivaev,Volker Borchers</authors>
     <owners>tunisiano</owners>
     <licenseUrl>https://github.com/freeplane/freeplane/blob/1.11.x/license.txt</licenseUrl>

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -36,6 +36,9 @@ function global:au_BeforeUpdate {
 	}
 	$destPath = "tools\$cleanFileName"
 	Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing
+	if (!(Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
+		throw "Installer download failed or produced an empty file: $destPath (from $($Latest.URL32))"
+	}
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
 	$Latest.ChecksumType32 = 'sha512'
 }
@@ -61,4 +64,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckChocoVersion

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -36,7 +36,7 @@ function global:au_BeforeUpdate {
 	}
 	$destPath = "tools\$cleanFileName"
 	Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing
-	if (!(Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
+	if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
 		throw "Installer download failed or produced an empty file: $destPath (from $($Latest.URL32))"
 	}
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash


### PR DESCRIPTION
## Summary
- Chocolatey moderation rejected FreePlane v1.13.3 with the installer missing entirely at install time (`Install-ChocolateyPackage` received an empty `-File`, i.e. `Get-Item tools\*.exe` found nothing).
- `au_BeforeUpdate` downloads the installer and computes its checksum, but never actually verified the download produced a real, non-empty file — a transient/partial download failure (SourceForge mirrors are known to be flaky) could silently continue past a broken download.
- Added an explicit `Test-Path` + size check right after the download that throws a clear error if it failed, so AU aborts the whole update instead of pushing a package with a missing installer.
- Reset nuspec to `0.0` + added `-NoCheckChocoVersion` to force AU to retry now that the guard is in place (per repo policy: valid when an actual code fix was made).

## Test plan
- [ ] Confirm the next AU run either pushes a package that installs cleanly, or aborts loudly with the new error message instead of silently pushing a broken one.
- [ ] Once it passes Chocolatey verification, remove `-NoCheckChocoVersion` per the one-time-flag cleanup policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_