### PR TITLE
fix(Executor): re-add -NoCheckChocoVersion to force fresh checksum re-push

### DIFF
--- a/automatic/Executor/update.ps1
+++ b/automatic/Executor/update.ps1
@@ -49,4 +49,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor 32 -NoCheckUrl
+update -ChecksumFor 32 -NoCheckUrl -NoCheckChocoVersion


### PR DESCRIPTION
## Summary
- Chocolatey moderation is still reporting a checksum mismatch for Executor: `executor.dk/ExecutorSetup.exe` is a rolling URL (same filename, content changes without a version bump), so a checksum computed at push time can go stale by the time chocolatey.org's review queue actually runs the install test.
- `au_BeforeUpdate` already recomputes the checksum fresh via `Get-RemoteChecksum` on every run (from #4236), so the checksum logic itself is correct. The nuspec is already at `0.0`, but without `-NoCheckChocoVersion`, AU's pre-push check sees a matching version already exists in the Chocolatey community feed and skips re-submitting — even though that existing submission is stuck failing verification.
- Re-adding `-NoCheckChocoVersion` makes AU actually retry with a checksum computed right now.

Note: this flag was added and reverted once already this week (#4262 / #4265) — the revert's stated reason was that a newer version (2.3.10) was confirmed live at the time, making the flag risk a `409 Conflict` retry of an already-superseded version. I wasn't able to independently re-verify chocolatey.org's current live state from this session (network-restricted), so if `2.3.10` (or newer) is in fact already approved and live, this PR is redundant and can be closed — but the moderation failure report currently in hand shows the checksum-mismatch state needing a fresh resubmit.

## Test plan
- [ ] Confirm the next AU run pushes a version that passes Chocolatey verification (not a 409 conflict on an already-live version).
- [ ] Once it passes, remove `-NoCheckChocoVersion` per the one-time-flag cleanup policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_