### PR TITLE
fix(Executor): set nuspec to 2.3.10, remove -NoCheckChocoVersion

### DIFF
--- a/automatic/Executor/Executor.nuspec
+++ b/automatic/Executor/Executor.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>Executor</id>
     <title>Executor</title>
-    <version>0.0</version>
+    <version>2.3.10</version>
     <authors>Martin Bresson</authors>
     <owners>tunisiano</owners>
     <packageSourceUrl>https://github.com/tunisiano187/Chocolatey-packages/tree/master/automatic/Executor</packageSourceUrl>

--- a/automatic/Executor/update.ps1
+++ b/automatic/Executor/update.ps1
@@ -49,4 +49,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor 32 -NoCheckUrl -NoCheckChocoVersion
+update -ChecksumFor 32 -NoCheckUrl


### PR DESCRIPTION
## Summary

Explicit exception authorized: the moderation failure this whole saga (#4262, #4265, #4302, #4303) reacted to was on `v2.3.9`, which is stale. `2.3.10` has been the live, approved version on chocolatey.org since 2026-07-20 (confirmed via the OData API). AppVeyor build #8920 confirmed the actual failure mode: with nuspec at `0.0` + `-NoCheckChocoVersion`, every AU run now tries to re-push `2.3.10` and hits a `409 Conflict` since it already exists.

- Set nuspec `<version>` to `2.3.10` to match the live gallery state.
- Remove `-NoCheckChocoVersion` — no longer needed once the nuspec matches reality.

## Note on checksum staleness (FYI, not fixed here)
`executor.dk/ExecutorSetup.exe` is a rolling URL. I downloaded the currently-live binary and its SHA256 (`54e6a5f...`) doesn't match what's committed in `tools/ChocolateyInstall.ps1` (`d930ca4...`) — expected, since the binary changes without any version signal. `au_BeforeUpdate` already recomputes this fresh via `Get-RemoteChecksum` on every run (from #4236), so the next time `au_GetLatest` detects a real version bump, the checksum gets refreshed automatically. Not addressing it in this PR since it's out of scope for the requested change.

## Test plan
- [ ] Confirm the next AU run reports "no update needed" cleanly (no 409) until executor.dk actually ships a new version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_