### PR TITLE
Potential fix for code scanning alert no. 7: Code injection

### DIFF
--- a/.github/workflows/edited-issue.yml
+++ b/.github/workflows/edited-issue.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Check exception
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.event.repository.full_name }}
+          ACTOR: ${{ github.event.issue.user.login }}
         run: |
           Import-Module "${{ github.workspace }}\scripts\edit.psm1"
-          Block-package -title "${{ github.event.issue.title }}" -issueNumber ${{ github.event.issue.number }} -repository "${{ github.event.repository.full_name }}" -actor "${{ github.event.issue.user.login }}"
+          Block-package -title "$env:ISSUE_TITLE" -issueNumber $env:ISSUE_NUMBER -repository "$env:REPOSITORY" -actor "$env:ACTOR"


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/7](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/7)

To fix this without changing behavior, move all untrusted GitHub context values currently embedded in the `run:` script into step-level environment variables, then read them in PowerShell using `$env:...`. This prevents expression-time injection into the script text while preserving the same arguments passed to `Block-package`.

In `.github/workflows/edited-issue.yml`, update the `Check exception` step:
- Add an `env:` block for:
  - `ISSUE_TITLE: ${{ github.event.issue.title }}`
  - `ISSUE_NUMBER: ${{ github.event.issue.number }}`
  - `REPOSITORY: ${{ github.event.repository.full_name }}`
  - `ACTOR: ${{ github.event.issue.user.login }}`
- Replace line 19 argument values to use PowerShell environment variables:
  - `-title "$env:ISSUE_TITLE"`
  - `-issueNumber $env:ISSUE_NUMBER`
  - `-repository "$env:REPOSITORY"`
  - `-actor "$env:ACTOR"`

This is the single best fix for this alert pattern and aligns with GitHub’s secure usage guidance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
