### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/edited-issue.yml
+++ b/.github/workflows/edited-issue.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [edited]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   validation:
     if: ${{ github.event.issue.state == 'open' && (contains(github.event.issue.title, 'exclude') || contains(github.event.issue.title, 'remove') || contains(github.event.issue.title, 'block')) }}


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/67](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/67)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` scopes are constrained and documented.  
Best single fix without changing behavior is to set permissions at the **workflow root** (applies to all jobs unless overridden), immediately under `on:` and before `jobs:`.

For this workflow:
- `contents: read` is required for `actions/checkout`.
- Because the script name and trigger strongly suggest issue moderation/action, include `issues: write` so issue updates/comments/state changes continue to work if performed by `Block-package`.

Edit only `.github/workflows/edited-issue.yml` by inserting:
```yml
permissions:
  contents: read
  issues: write
```
between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
