### PR TITLE
Potential fix for code scanning alert no. 66: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/66](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/66)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained by least privilege instead of inheriting defaults.

Best fix (without changing functionality): in `.github/workflows/sonarcloud.yml`, add a root-level permissions section after the `on:` triggers (or after `name:`) with at least:
- `contents: read`

This preserves current behavior (checkout + scan) while documenting and enforcing minimal token access for all jobs in this workflow.

No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
