### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push-package.yml
+++ b/.github/workflows/push-package.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   push:
     runs-on: windows-2025


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/65](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/65)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to the minimum required scope.

Best fix here: add a workflow-level block directly under `on:` (or before `jobs:`) with:

- `contents: read`

This preserves existing functionality (`actions/checkout` requires read access to repository contents) and avoids granting unnecessary write scopes. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
