### PR TITLE
fix(freeplane): verify PE 'MZ' header, not just non-empty file

### DIFF
--- a/automatic/freeplane/freeplane.nuspec
+++ b/automatic/freeplane/freeplane.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>freeplane</id>
     <title>Freeplane</title>
-    <version>1.13.3</version>
+    <version>0.0</version>
     <authors>Dimitry Polivaev,Volker Borchers</authors>
     <owners>tunisiano</owners>
     <licenseUrl>https://github.com/freeplane/freeplane/blob/1.11.x/license.txt</licenseUrl>

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -39,6 +39,17 @@ function global:au_BeforeUpdate {
 	if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
 		throw "Installer download failed or produced an empty file: $destPath (from $($Latest.URL32))"
 	}
+	# A non-empty file isn't proof of a valid installer: SourceForge occasionally serves a small
+	# HTML page (bot-block / mirror-choice interstitial) instead of the binary, which still has a
+	# non-zero size and would previously slip through here, get pushed, and fail Chocolatey
+	# verification with no exe found. Confirm it's actually a Windows PE executable by checking
+	# for the 'MZ' DOS header magic bytes.
+	$header = [byte[]]::new(2)
+	$stream = [System.IO.File]::OpenRead($destPath)
+	try { $stream.Read($header, 0, 2) | Out-Null } finally { $stream.Close() }
+	if ($header[0] -ne 0x4D -or $header[1] -ne 0x5A) {
+		throw "Downloaded file is not a valid Windows executable (missing 'MZ' header): $destPath (from $($Latest.URL32))"
+	}
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
 	$Latest.ChecksumType32 = 'sha512'
 }


### PR DESCRIPTION
## Summary

Follow-up correction to #4301. That PR's empty-file guard wasn't enough: `v1.13.3` still failed Chocolatey verification. Confirmed via the moderation test's file-snapshot gist (linked from the failure email) — `tools\` contains no `.exe` at all in the tested package.

Root cause: a non-empty downloaded file isn't proof of a valid installer. SourceForge occasionally serves a small HTML interstitial (bot-block / mirror-choice page) instead of the actual binary — non-zero size, so it sailed right past the previous check, got checksummed, packaged, and pushed with a broken `tools\` directory.

## Changes
- After download, verify the file actually starts with the `MZ` DOS header (the real signature of a Windows PE executable), not just that it's non-empty. Throws a clear error otherwise.
- Reset nuspec to `0.0` (keeping `-NoCheckChocoVersion`, already present) to force a fresh resubmit with this stricter guard.

Verified locally: the check correctly returns true for a real `.exe` and false for an HTML file.

## Test plan
- [ ] Confirm the next AU run either pushes a package that passes Chocolatey verification, or aborts loudly with the new "not a valid Windows executable" error instead of silently pushing a broken one again.

---