### PR TITLE
fix(freeplane): download installer at install time instead of embedding it

### DIFF
--- a/automatic/freeplane/tools/chocolateyInstall.ps1
+++ b/automatic/freeplane/tools/chocolateyInstall.ps1
@@ -1,12 +1,15 @@
-﻿$packageName = $env:ChocolateyPackageName
-$installerType = 'exe'
-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
-$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
-$File = Get-Item $toolsPath\*.exe
+$ErrorActionPreference = 'Stop'
+$packageName   = $env:ChocolateyPackageName
+$url           = 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/Freeplane-Setup-1.13.3.exe/download'
+$checksum      = '8D815B9EB95C1D3F2D6B5194DCF3440FA47E9850B6E9562B69F1C925134487597816FB825F184D3495B30C78330EB6FE92C4670326A49A97A8C3FE53DFA567EB'
+$checksumType  = 'sha512'
+$silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 $validExitCodes = @(0)
 
 Install-ChocolateyPackage -PackageName "$packageName" `
-                          -FileType "$installerType" `
+                          -FileType 'exe' `
+                          -Url "$url" `
+                          -Checksum "$checksum" `
+                          -ChecksumType "$checksumType" `
                           -SilentArgs "$silentArgs" `
-                          -File "$File" `
                           -ValidExitCodes $validExitCodes

--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -11,6 +11,11 @@ function global:au_SearchReplace {
 			"(?i)(Get-RemoteChecksum).*"        = "`${1} $($Latest.URL32)"
 			"(?i)(\s+checksum32:).*"            = "`${1} $($Latest.Checksum32)"
 		}
+		'tools\chocolateyInstall.ps1' = @{
+			"(^\s*[$]url\s*=\s*)('.*')"           = "`$1'$($Latest.URL32)'"
+			"(^\s*[$]checksum\s*=\s*)('.*')"      = "`$1'$($Latest.Checksum32)'"
+			"(^\s*[$]checksumType\s*=\s*)('.*')"  = "`$1'$($Latest.ChecksumType32)'"
+		}
 	}
 }
 
@@ -25,25 +30,21 @@ function global:au_BeforeUpdate {
 		# Fall back to 1.12.x if the branch-specific URL fails
 		Invoke-WebRequest -Uri "https://raw.githubusercontent.com/freeplane/freeplane/1.12.x/license.txt" -OutFile "legal\LICENSE.txt" -UseBasicParsing
 	}
-	# Clean up any old installer files before downloading the new one
-	Get-ChildItem "tools\*.exe" -ErrorAction SilentlyContinue | Remove-Item -Force
-	# SourceForge URLs end with /download; extract the .exe filename from the second-to-last path segment
-	$urlSegments = ([uri]$Latest.URL32).AbsolutePath -split '/' | Where-Object { $_ }
-	$cleanFileName = if ($urlSegments[-1] -eq 'download') {
-		[uri]::UnescapeDataString($urlSegments[-2])
-	} else {
-		[System.IO.Path]::GetFileName(([uri]$Latest.URL32).LocalPath)
-	}
-	$destPath = "tools\$cleanFileName"
+	# The installer is no longer embedded in the package (see #4298/#4312 history): chocolateyInstall.ps1
+	# now downloads it fresh at install time via -Url/-Checksum, so the packaging step can no longer lose
+	# a bundled file. We still need to download it here once, to a scratch location outside the package
+	# directory, purely to compute a checksum for chocolateyInstall.ps1's -Checksum parameter.
+	$destPath = Join-Path $env:TEMP "freeplane-$($Latest.Version).exe"
 	Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing
 	if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
 		throw "Installer download failed or produced an empty file: $destPath (from $($Latest.URL32))"
 	}
 	# A non-empty file isn't proof of a valid installer: SourceForge occasionally serves a small
 	# HTML page (bot-block / mirror-choice interstitial) instead of the binary, which still has a
-	# non-zero size and would previously slip through here, get pushed, and fail Chocolatey
-	# verification with no exe found. Confirm it's actually a Windows PE executable by checking
-	# for the 'MZ' DOS header magic bytes.
+	# non-zero size. Confirm it's actually a Windows PE executable by checking for the 'MZ' DOS
+	# header magic bytes -- if this passes, the checksum baked into chocolateyInstall.ps1 is
+	# guaranteed to correspond to a real installer, and Chocolatey's own -Checksum verification at
+	# install time protects against the URL serving something different later.
 	$header = [byte[]]::new(2)
 	$stream = [System.IO.File]::OpenRead($destPath)
 	try { $stream.Read($header, 0, 2) | Out-Null } finally { $stream.Close() }
@@ -52,6 +53,7 @@ function global:au_BeforeUpdate {
 	}
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
 	$Latest.ChecksumType32 = 'sha512'
+	Remove-Item -Path $destPath -Force -ErrorAction SilentlyContinue
 }
 
 function global:au_AfterUpdate($Package) {


### PR DESCRIPTION
## Summary

Even after #4312's stricter 'MZ' header check, `v1.13.3` still failed Chocolatey moderation with no `.exe` present in `tools\`. Rather than keep chasing every possible way the AppVeyor build/pack step could lose a file staged during `au_BeforeUpdate`, this switches the package to the pattern most other packages here already use: download the installer **at install time**, not bundle it in the nupkg.

## Changes
- `tools/chocolateyInstall.ps1`: switched from `-File` (embedded, pre-downloaded binary) to `-Url`/`-Checksum`/`-ChecksumType` (downloads fresh on the end-user's/Chocolatey test machine at install time) — same pattern as `Executor`.
- `au_BeforeUpdate`: still downloads the installer once (now to a scratch path outside the package directory, not `tools\`) purely to verify it via the existing `MZ` PE-header check and compute a checksum. No longer needs to persist the file for packaging — deletes it after hashing.
- `au_SearchReplace`: now also patches `url`/`checksum`/`checksumType` directly in `chocolateyInstall.ps1` (previously only `VERIFICATION.txt` was patched). Verified the regex against the real file locally (fixed a bug in my first attempt — `` `$url `` leaves an unescaped `$` which is a regex end-of-string anchor, not a literal dollar sign; switched to the `[$]` convention already used elsewhere in this repo).

nuspec stays at `0.0` with `-NoCheckChocoVersion` already in place (#4312), so the next AU run picks this up automatically.

## Test plan
- [ ] Confirm the next AU run pushes a package that installs cleanly (downloads the .exe fresh, checksum matches) and passes Chocolatey verification.

---