### PR TITLE
fix(freeplane): retry via pinned SourceForge mirrors when auto-selection fails

### DIFF
--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -34,22 +34,45 @@ function global:au_BeforeUpdate {
 	# now downloads it fresh at install time via -Url/-Checksum, so the packaging step can no longer lose
 	# a bundled file. We still need to download it here once, to a scratch location outside the package
 	# directory, purely to compute a checksum for chocolateyInstall.ps1's -Checksum parameter.
-	$destPath = Join-Path $env:TEMP "freeplane-$($Latest.Version).exe"
-	Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing
-	if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
-		throw "Installer download failed or produced an empty file: $destPath (from $($Latest.URL32))"
+	# SourceForge's "direct download" URLs end in a trailing "/download" segment (e.g.
+	# .../Freeplane-Setup-1.13.3.exe/download) -- that trailing segment is not part of the real file
+	# name, so it has to be stripped before taking the last path segment, otherwise the derived name
+	# is just the literal word "download".
+	$fileName = ($Latest.URL32 -replace '/download$', '').Split('/')[-1]
+	if (-not $fileName) { $fileName = "freeplane-$($Latest.Version).exe" }
+	$destPath = Join-Path $env:TEMP $fileName
+
+	# SourceForge's automatic mirror selection (the plain "/download" URL) is unreliable from CI /
+	# datacenter IPs: instead of a redirect to a real binary it can serve a small HTML "choose a
+	# mirror" / bot-block page that still downloads instantly and has a non-zero size (this is why
+	# the download here completed in under a second for a 150+ MB installer). It's consistently
+	# reliable from residential/office IPs, which is why this doesn't reproduce locally. Retry
+	# against a couple of explicitly pinned mirrors (?use_mirror=...) before giving up -- the file
+	# content, and therefore its checksum, is identical regardless of which mirror serves it.
+	$downloadUrls = @($Latest.URL32) + @('netcologne', 'deac-riga', 'excellmedia') | ForEach-Object {
+		if ($_ -eq $Latest.URL32) { $_ } else { "$($Latest.URL32)?use_mirror=$_" }
 	}
-	# A non-empty file isn't proof of a valid installer: SourceForge occasionally serves a small
-	# HTML page (bot-block / mirror-choice interstitial) instead of the binary, which still has a
-	# non-zero size. Confirm it's actually a Windows PE executable by checking for the 'MZ' DOS
-	# header magic bytes -- if this passes, the checksum baked into chocolateyInstall.ps1 is
-	# guaranteed to correspond to a real installer, and Chocolatey's own -Checksum verification at
-	# install time protects against the URL serving something different later.
-	$header = [byte[]]::new(2)
-	$stream = [System.IO.File]::OpenRead($destPath)
-	try { $stream.Read($header, 0, 2) | Out-Null } finally { $stream.Close() }
-	if ($header[0] -ne 0x4D -or $header[1] -ne 0x5A) {
-		throw "Downloaded file is not a valid Windows executable (missing 'MZ' header): $destPath (from $($Latest.URL32))"
+
+	$validExe = $false
+	foreach ($attemptUrl in $downloadUrls) {
+		try {
+			Invoke-WebRequest -Uri $attemptUrl -OutFile $destPath -UseBasicParsing -ErrorAction Stop
+		} catch {
+			continue
+		}
+		if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) { continue }
+		# A non-empty file isn't proof of a valid installer (see comment above). Confirm it's
+		# actually a Windows PE executable by checking for the 'MZ' DOS header magic bytes -- if
+		# this passes, the checksum baked into chocolateyInstall.ps1 is guaranteed to correspond to
+		# a real installer, and Chocolatey's own -Checksum verification at install time protects
+		# against the URL serving something different later.
+		$header = [byte[]]::new(2)
+		$stream = [System.IO.File]::OpenRead($destPath)
+		try { $stream.Read($header, 0, 2) | Out-Null } finally { $stream.Close() }
+		if ($header[0] -eq 0x4D -and $header[1] -eq 0x5A) { $validExe = $true; break }
+	}
+	if (-not $validExe) {
+		throw "Downloaded file is not a valid Windows executable (missing 'MZ' header) after trying the default URL and fallback mirrors: $destPath (from $($Latest.URL32))"
 	}
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
 	$Latest.ChecksumType32 = 'sha512'


### PR DESCRIPTION
## Why

AppVeyor build [#8937](https://ci.appveyor.com/project/tunisiano187/chocolatey-packages/builds/54476741) re-triggered the MZ-header guard added in #4312 for `freeplane`:

```
Downloaded file is not a valid Windows executable (missing 'MZ' header): C:\Users\appveyor\AppData\Local\Temp\1\freeplane-1.13.3.exe (from https://sourceforge.net/projects/freeplane/files/freeplane%20stable/Freeplane-Setup-1.13.3.exe/download)
```

The log shows the download completing in the same second it started, for what should be a 150+ MB installer — and it does not reproduce on a normal PC.

**Root cause**: SourceForge's automatic mirror selection (the plain `.../download` URL) is geoip/reputation-based and unreliable from CI / datacenter IPs — it can serve a small HTML "choose a mirror" page instead of redirecting to the real binary, while it reliably resolves correctly from residential/office IPs. This is a documented, known SourceForge behavior for automated clients hitting it from cloud IP ranges.

Verified live from this environment: the default `/download` URL and several explicitly pinned mirrors (`?use_mirror=netcologne`, `?use_mirror=deac-riga`, `?use_mirror=excellmedia`) were downloaded directly — same file, same `MZ` header, same size on the reliable ones; one pinned mirror (`excellmedia`) failed on a retry, confirming individual mirrors are also individually flaky, which is why the fix tries several rather than pinning a single one.

## What changed

`automatic/freeplane/update.ps1`, `au_BeforeUpdate`:
- Derives the scratch download file name by stripping SourceForge's trailing `/download` segment from the URL (matches the existing convention documented in `scripts/Invoke-VirusTotalScan.ps1`), instead of assuming a hardcoded `freeplane-$Version.exe` name.
- On download, retries against a short list of pinned mirrors if the default auto-selected mirror doesn't yield a valid PE (`MZ` header check, from #4312), before finally throwing. Since it's the same file content on every mirror, the checksum computed is unaffected by which mirror actually served it.

## Testing

- `pwsh -NoProfile` AST parse of the modified script: no syntax errors.
- Isolated `pwsh` test of the URL-list construction and filename derivation against the real `$Latest.URL32` value from build #8937 — confirmed correct mirror URLs and `Freeplane-Setup-1.13.3.exe` file name.
- Direct `curl` against the real SourceForge URLs (default + all 3 pinned mirrors) confirmed the default and two of the three pinned mirrors return a genuine `MZ`-headed PE of identical size (107,309,432 bytes); the third mirror failed on a retry attempt, which is expected/handled by trying multiple mirrors.

---