### PR TITLE
fix(ci): anchor commit-message package-detection regex to diffstat lines

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -155,7 +155,11 @@ build_script:
                 return
             }
         }
-        $lastupdated=git log -1 --stat | Where-Object {$_ -match "automatic"} | Where-Object {$_ -notmatch "'automatic"}
+        # Anchored to the start of the line (ignoring leading whitespace) so this only matches real
+        # `git log --stat` diffstat lines (e.g. " automatic/freeplane/update.ps1 | 28 ++--"), not
+        # commit-message prose that happens to contain "automatic" as a substring (e.g. "...picks
+        # this up automatically."), which used to be split into bogus package name tokens.
+        $lastupdated=git log -1 --stat | Where-Object {$_ -match "^\s*automatic/"} | Where-Object {$_ -notmatch "'automatic"}
         if($lastupdated.Count -ne 0 -and ($Env:APPVEYOR_SCHEDULED_BUILD -ne 'true')) {
           $Env:au_Push = "false"
           $packages = $lastupdated.split('/').split(' ')


### PR DESCRIPTION
## Why

AppVeyor build [#8937](https://ci.appveyor.com/project/tunisiano187/chocolatey-packages/builds/54476741) logged a run of bogus warnings after PR #4314 merged:

```
Can't find package 'so'
Can't find package 'the'
Can't find package 'next'
Can't find package 'AU'
Can't find package 'run'
Can't find package 'picks'
Can't find package 'this'
Can't find package 'up'
Can't find package 'automatically.'
```

These are word fragments from that PR's commit message body ("...so the next AU run picks this up automatically."), not real package names — noise, not a build failure by itself, but a real bug in the detection logic.

**Root cause**: `.appveyor.yml` line 158 filters `git log -1 --stat` output with an unanchored substring match:

```powershell
$lastupdated=git log -1 --stat | Where-Object {$_ -match "automatic"} | Where-Object {$_ -notmatch "'automatic"}
```

`git log --stat` prints the full commit message body *before* the diffstat lines. Real diffstat lines look like `` automatic/freeplane/update.ps1 | 28 ++--`` — but any commit message body line containing "automatic" as a substring anywhere (here, "...automatically.") also matches, gets treated as if it were a diffstat line, and is split into fake package tokens by the code right after.

## Fix

Anchor the match to the start of the line (ignoring leading whitespace): `-match "^\s*automatic/"`. Verified with an isolated `pwsh` test reproducing the exact build #8937 commit message + diffstat shape — the anchored regex matches only the two real diffstat lines, not the prose line.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"`: YAML still parses correctly.
- Isolated `pwsh` test against a sample `git log -1 --stat`-shaped string built from the actual PR #4314 commit message + diffstat: confirmed the old regex matches the prose line + both diffstat lines, the new regex matches only the two diffstat lines.

---