### PR TITLE
fix(freeplane): correct SourceForge mirror-pinning assumption, add retry diagnostics

### DIFF
--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -44,23 +44,31 @@ function global:au_BeforeUpdate {
 
 	# SourceForge's automatic mirror selection (the plain "/download" URL) is unreliable from CI /
 	# datacenter IPs: instead of a redirect to a real binary it can serve a small HTML "choose a
-	# mirror" / bot-block page that still downloads instantly and has a non-zero size (this is why
-	# the download here completed in under a second for a 150+ MB installer). It's consistently
-	# reliable from residential/office IPs, which is why this doesn't reproduce locally. Retry
-	# against a couple of explicitly pinned mirrors (?use_mirror=...) before giving up -- the file
-	# content, and therefore its checksum, is identical regardless of which mirror serves it.
-	$downloadUrls = @($Latest.URL32) + @('netcologne', 'deac-riga', 'excellmedia') | ForEach-Object {
-		if ($_ -eq $Latest.URL32) { $_ } else { "$($Latest.URL32)?use_mirror=$_" }
-	}
-
+	# mirror" / bot-block page that still downloads instantly and has a non-zero size. It's
+	# consistently reliable from residential/office IPs, which is why this doesn't reproduce
+	# locally. A previous version of this fix tried pinning specific mirrors via "?use_mirror=...",
+	# but live testing proved SourceForge's redirect silently ignores/overrides that hint -- the
+	# same "?use_mirror=netcologne" request came back mapped to "pilotfiber", then "netactuate" on
+	# separate attempts. What actually varies per request is SourceForge's own (unpinnable) mirror
+	# assignment, so instead just retry the same URL a few times with a short delay -- each retry
+	# gets a fresh assignment, improving the odds of landing on a mirror that works for this IP.
+	$maxAttempts = 5
 	$validExe = $false
-	foreach ($attemptUrl in $downloadUrls) {
+	$lastFailureDetail = $null
+	for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
 		try {
-			Invoke-WebRequest -Uri $attemptUrl -OutFile $destPath -UseBasicParsing -ErrorAction Stop
+			$response = Invoke-WebRequest -Uri $Latest.URL32 -OutFile $destPath -UseBasicParsing -ErrorAction Stop -PassThru
+			$lastFailureDetail = "HTTP $($response.StatusCode), Content-Type: $($response.Headers['Content-Type']), $((Get-Item $destPath).Length) bytes"
 		} catch {
+			$lastFailureDetail = "request failed: $_"
+			Start-Sleep -Seconds 3
 			continue
 		}
-		if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) { continue }
+		if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
+			$lastFailureDetail = "empty file ($lastFailureDetail)"
+			Start-Sleep -Seconds 3
+			continue
+		}
 		# A non-empty file isn't proof of a valid installer (see comment above). Confirm it's
 		# actually a Windows PE executable by checking for the 'MZ' DOS header magic bytes -- if
 		# this passes, the checksum baked into chocolateyInstall.ps1 is guaranteed to correspond to
@@ -70,9 +78,11 @@ function global:au_BeforeUpdate {
 		$stream = [System.IO.File]::OpenRead($destPath)
 		try { $stream.Read($header, 0, 2) | Out-Null } finally { $stream.Close() }
 		if ($header[0] -eq 0x4D -and $header[1] -eq 0x5A) { $validExe = $true; break }
+		$lastFailureDetail = "missing 'MZ' header ($lastFailureDetail)"
+		Start-Sleep -Seconds 3
 	}
 	if (-not $validExe) {
-		throw "Downloaded file is not a valid Windows executable (missing 'MZ' header) after trying the default URL and fallback mirrors: $destPath (from $($Latest.URL32))"
+		throw "Downloaded file is not a valid Windows executable after $maxAttempts attempts: $destPath (from $($Latest.URL32)). Last failure: $lastFailureDetail"
 	}
 	$Latest.Checksum32 = (Get-FileHash -Path $destPath -Algorithm SHA512).Hash
 	$Latest.ChecksumType32 = 'sha512'


### PR DESCRIPTION
## Why

The manually-triggered AppVeyor build [#8940](https://ci.appveyor.com/project/tunisiano187/chocolatey-packages/builds/54476796) proved #4315's mirror-pinning fix didn't actually work:

```
[65/209] freeplane ERROR:
  Downloaded file is not a valid Windows executable (missing 'MZ' header) after trying the default URL and fallback mirrors: ...Freeplane-Setup-1.13.3.exe (8.95s)
```

All 4 attempts (default URL + 3 pinned mirrors) failed in under 9 seconds total.

## Root cause of #4315's failure

Live-tested directly: repeatedly requesting `.../download?use_mirror=netcologne` does **not** reliably return the `netcologne` mirror — SourceForge's redirect service returned `pilotfiber`, then `netactuate` on separate identical requests, silently ignoring/overriding the `use_mirror` query parameter. So #4315's "4 different pinned URLs" were actually 4 no-op requests to the same auto-assignment lottery, which explains why they could all fail together — pinning was never actually pinning anything.

Separately, also observed directly: downloading the real 107MB installer repeatedly in quick succession can hit a genuine `Connection reset by peer` after a few large transfers — a real, retryable network condition, distinct from the HTML-interstitial case the existing `MZ`-header check (from #4312) already catches.

## Fix

- Removes the ineffective `?use_mirror=...` pinning.
- Retries the plain URL up to 5 times with a 3s delay — each retry does get a fresh (unpinnable) mirror assignment from SourceForge, so repetition itself is what improves the odds, not the query parameter.
- Captures the HTTP status/content-type/size of the last response (or the exception message) into the thrown error, so if this fails again on AppVeyor the message says *why* (blocked/interstitial vs. connection reset vs. empty file) instead of just "missing MZ header" — needed since this failure mode doesn't reproduce locally and the previous fix's premise turned out to be wrong.

## Testing

- `pwsh -NoProfile` AST parse: no syntax errors.
- Verified `-OutFile` + `-PassThru` together on `Invoke-WebRequest` works as expected (returns the response object while still writing to disk).
- Directly reproduced the mirror-pinning failure live (see root cause above).
- Directly reproduced a transient `Connection reset by peer` on repeated real downloads, then confirmed a subsequent retry succeeds.

---