### PR TITLE
freeplane: remove -NoCheckChocoVersion flag

### DIFF
--- a/automatic/freeplane/update.ps1
+++ b/automatic/freeplane/update.ps1
@@ -60,4 +60,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none -NoCheckChocoVersion
+update -ChecksumFor none


### PR DESCRIPTION
## Summary

Removes the `-NoCheckChocoVersion` flag from `freeplane/update.ps1`.

The flag was added as a one-time measure to allow AU to re-push the package bypassing the Chocolatey version check. AU has since successfully updated and re-submitted freeplane — the nuspec is now at version `1.13.3` (no longer `0.0`), confirming the re-push completed. The flag is no longer needed and would cause unnecessary bypasses on future AU runs.

## Change

- `automatic/freeplane/update.ps1`: `update -ChecksumFor none -NoCheckChocoVersion` → `update -ChecksumFor none`