### PR TITLE
fix(ddu): fix download URL (moved to download.wagnardsoft.com)

### DIFF
--- a/automatic/ddu/update.ps1
+++ b/automatic/ddu/update.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 import-module chocolatey-AU
 
-# Changed from forums (Cloudflare IUAM) to the main DDU page which is accessible.
-# Direct download URL pattern: https://www.wagnardsoft.com/DDU/download/DDU%20v{version}.exe
+# Versions are scraped from the main DDU page (no Cloudflare challenge).
+# Downloads are served from download.wagnardsoft.com (no referer required).
 $releases = "https://www.wagnardsoft.com/display-driver-uninstaller-ddu"
 
 function global:au_SearchReplace {
@@ -11,7 +11,6 @@ function global:au_SearchReplace {
 			"(^[$]url\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
 			"(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
 			"(^[$]checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
-			"(^[$]referer\s*=\s*)('.*')" = "`$1'$($Latest.Referer)'"
 		}
 	}
 }
@@ -34,10 +33,9 @@ function global:au_GetLatest {
 		throw "Could not extract DDU version from $releases"
 	}
 
-	$url32   = "https://www.wagnardsoft.com/DDU/download/DDU%20v$version.exe"
-	$referer = $releases
+	$url32 = "https://download.wagnardsoft.com/DDU/DDU%20v$version.exe"
 
-	return @{ URL32 = $url32; Referer = $referer; Version = $version }
+	return @{ URL32 = $url32; Version = $version }
 }
 
 


### PR DESCRIPTION
## Summary

Fixes #4322 — Update Request for DDU 18.1.5.6.

### Root cause

Wagnardsoft moved the DDU download CDN from `www.wagnardsoft.com/DDU/download/` to `download.wagnardsoft.com/DDU/`. The old path returns HTTP 404 for versions ≥ 18.1.5.5, which is why AU has been unable to auto-update DDU since 18.1.5.4 (last updated 2026-05-30).

### Change — `update.ps1` only

- URL template in `au_GetLatest`: `www.wagnardsoft.com/DDU/download/` → `download.wagnardsoft.com/DDU/`
- Removed `Referer` from `au_GetLatest` return and from `au_SearchReplace` (new CDN requires no referer)
- Updated comment

AU will detect the version bump on its next scheduled run and update `chocolateyInstall.ps1` + `ddu.nuspec` automatically.

### Verification

- `https://download.wagnardsoft.com/DDU/DDU%20v18.1.5.6.exe` → HTTP 200, no Referer header needed
- Same pattern works for 18.1.5.4 and 18.1.5.5