### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/improve_scripts.yml
+++ b/.github/workflows/improve_scripts.yml
@@ -1,5 +1,8 @@
 ﻿name: Package improver
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/64](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/64)

To fix this, add an explicit `permissions` block to `.github/workflows/improve_scripts.yml`.  
Best practice here is to set least privilege at workflow root so it applies to all jobs unless overridden. For the current steps (`checkout`, git config, and running a script), the minimal baseline recommended by CodeQL is `contents: read`.

**Change location:** near the top of the workflow, after `name:` and before `on:` (or alternatively under the specific job).  
**Needed additions:** only YAML keys; no imports, methods, or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
