### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   CheckpackageRequest:
     runs-on: windows-2025


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/61](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/61)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default. The safest non-breaking baseline is to set workflow-level `permissions` to `contents: read`, which is the minimal recommended starting point and aligns with CodeQL’s guidance.

In `.github/workflows/new-issue.yml`, insert a top-level `permissions:` section after the `on:` trigger block (before `jobs:`). This applies to all jobs unless overridden. No imports, methods, or external dependencies are needed. If later testing shows the PowerShell module needs extra scopes (for example, writing issues/comments), add only those specific write permissions at job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
