### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily-surveillance.yml
+++ b/.github/workflows/daily-surveillance.yml
@@ -7,6 +7,10 @@ on:
     - cron: '30 6 * * *'  # 06:30 UTC
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   surveillance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/52](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/52)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` has only the scopes required by this job:

- `contents: write` (needed for commit/push to repository)
- `issues: write` (needed for issue creation and issue comments)

Best single fix without changing behavior: insert `permissions` at the workflow root (applies to all jobs unless overridden). This is the least invasive and fully addresses the CodeQL finding while preserving current workflow functionality.

Edit only `.github/workflows/daily-surveillance.yml`, near the top-level keys (`name`, `on`, `jobs`), by inserting the permissions block between `on` and `jobs` (or any top-level position).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
