### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gpu-price-check.yml
+++ b/.github/workflows/gpu-price-check.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 8 * * 1,4'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-price:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/23](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/23)

Add an explicit `permissions` block to the workflow with the minimum needed scope.  
For this workflow, the safest non-breaking choice is to set read-only repository content access:

- `permissions:`
  - `contents: read`

Place this at the workflow root (after `on:` and before `jobs:`), so it applies to all jobs unless overridden later. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
