### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,9 @@ on:
   pull_request:
     types: [opened, reopened]
 name: Pull Request
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   assignAuthor:
     name: Assign author to PR


### PR DESCRIPTION
Potential fix for [https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/6](https://github.com/tunisiano187/Chocolatey-packages/security/code-scanning/6)

Add an explicit `permissions` block to `.github/workflows/pull_request.yml` so the workflow does not rely on repository/org defaults.  
Best fix here: define workflow-level minimal permissions and grant only what this PR-assignment workflow needs.

For this file, add at the root (after `name`) a `permissions` section with:
- `contents: read` (safe baseline read access)
- `pull-requests: write` (required to update PR assignment)

No imports, methods, or dependencies are needed—just YAML configuration in the shown workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
