### PR TITLE
fix(osfmount): Move-Item -Force so au_BeforeUpdate doesn't silently drop the exe

### DIFF
--- a/automatic/osfmount/osfmount.nuspec
+++ b/automatic/osfmount/osfmount.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>osfmount</id>
-    <version>3.2.1001.0</version>
+    <version>0.0</version>
     <title>OSFMount (Install)</title>
     <authors>PassMark(r) Software Pty Ltd</authors>
     <owners>tunisiano</owners>

--- a/automatic/osfmount/update.ps1
+++ b/automatic/osfmount/update.ps1
@@ -14,7 +14,20 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate {
 	. ..\..\scripts\Get-FileVersion.ps1
 	$FileVersion = Get-FileVersion $Latest.URL32 -keep
-	Move-Item -Path $FileVersion.TempFile -Destination "tools\osfmount.exe"
+	$destPath = "tools\osfmount.exe"
+	# Without -Force, Move-Item silently no-ops (well, throws a *non-terminating* error) if
+	# $destPath already exists -- e.g. left over from a previous run on a reused AppVeyor
+	# workspace. Combined with $ErrorActionPreference not reliably propagating into this
+	# global function (it's invoked from deep inside the AU module, in a different scope),
+	# that non-terminating error was getting swallowed: au_BeforeUpdate would report success,
+	# choco pack would silently build a .nupkg with no tools\osfmount.exe at all, and AU would
+	# push it -- which is exactly what happened for v3.2.1000/3.2.1001 (confirmed by pulling
+	# the actual pushed .nupkg from chocolatey.org: it contains chocolateyinstall.ps1 but no
+	# osfmount.exe). -Force makes the move actually succeed instead of silently no-op.
+	Move-Item -Path $FileVersion.TempFile -Destination $destPath -Force
+	if (-not (Test-Path $destPath) -or (Get-Item $destPath).Length -eq 0) {
+		throw "osfmount.exe failed to land in tools\ after Move-Item: $destPath (from $($Latest.URL32))"
+	}
 	$Latest.Checksum32 = $FileVersion.Checksum
 	$Latest.ChecksumType32 = $FileVersion.checksumType
 }
@@ -33,4 +46,4 @@ function global:au_GetLatest {
 	return @{ URL32 = $url32; Version = $version }
 }
 
-update -NoCheckUrl -ChecksumFor none
+update -NoCheckUrl -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
## Why

`osfmount` failed Chocolatey moderation twice in a row (v3.2.1000 on Aug 7, v3.2.1001 on Aug 10), both "Failed Verification Testing". The moderation gist's file snapshot showed `tools\chocolateyinstall.ps1` and a stray `tools\osfmount.exe.ignore` — but **no `osfmount.exe`**.

Confirmed directly: downloaded the actual pushed `.nupkg` from `https://community.chocolatey.org/api/v2/package/osfmount/3.2.1001` and unzipped it — `tools\` really does contain only `chocolateyinstall.ps1`, no `osfmount.exe`. (The `.exe.ignore` companion file is expected/normal: `Install-ChocolateyInstallPackage` auto-generates it during install regardless of whether the target file exists — not itself evidence of anything wrong.)

AppVeyor's build log (build #8984) shows `[129/209] osfmount is updated to 3.2.1001.0 and pushed (66.28s)` — **no error at all**. AU believed the update succeeded.

## Root cause

```powershell
Move-Item -Path $FileVersion.TempFile -Destination "tools\osfmount.exe"
```

No `-Force`. `Move-Item` fails (as a *non-terminating* error) if the destination already exists — plausible on a reused AppVeyor workspace across scheduled runs. That non-terminating error doesn't reliably respect `update.ps1`'s script-scoped `$ErrorActionPreference = 'Stop'`, because `au_BeforeUpdate` is invoked as a `global:` function from deep inside the `chocolatey-au` module's `Update-Package`, in a different scope — the same class of scoping pitfall already found and fixed elsewhere in this repo (`gsuite-sync-outlook`). So the failure got swallowed, execution continued past it, `choco pack` built a `.nupkg` with no installer in it, and AU happily reported "pushed".

## Fix

- `Move-Item ... -Force`, so the move actually succeeds instead of silently no-op'ing.
- A `Test-Path`/size check immediately after that `throw`s if the file still isn't there for any other reason, instead of letting a broken package reach `choco pack` silently.

## Why nuspec → 0.0 + -NoCheckChocoVersion

`osfmount`'s download URL is a static "always current" link (no version in the path) — AU only detects "an update is available" by diffing the downloaded exe's own embedded version against the nuspec version. Since the nuspec is already sitting at `3.2.1001.0` (matching upstream's current build), AU has no natural signal that a re-push is needed after a code-only fix like this one. This is the repo's documented exception for rolling URLs (2026-07-24 amendment to `CLAUDE.md`) — same treatment already used for `Executor` and `freeplane` in this repo's history.

## Testing

- `pwsh -NoProfile` AST parse of `update.ps1`: no syntax errors.
- `nuspec` XML parses correctly.
- Verified the actual root cause by downloading and unzipping the real pushed `.nupkg` directly from chocolatey.org rather than guessing from logs.

---