### PR TITLE
fix(osfmount): set Latest.FileName32 so VirusTotal scan doesn't delete the embedded exe

### DIFF
--- a/automatic/osfmount/osfmount.nuspec
+++ b/automatic/osfmount/osfmount.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>osfmount</id>
-    <version>3.2.1001.0</version>
+    <version>0.0</version>
     <title>OSFMount (Install)</title>
     <authors>PassMark(r) Software Pty Ltd</authors>
     <owners>tunisiano</owners>

--- a/automatic/osfmount/update.ps1
+++ b/automatic/osfmount/update.ps1
@@ -30,6 +30,16 @@ function global:au_BeforeUpdate {
 	}
 	$Latest.Checksum32 = $FileVersion.Checksum
 	$Latest.ChecksumType32 = $FileVersion.checksumType
+	# The real bug: scripts/Invoke-VirusTotalScan.ps1 (called from au_AfterUpdate) treats an
+	# unset $Latest.FileName32 as "no file has been tracked yet" -- it re-downloads via its own
+	# Get-RemoteFiles into tools\ for scanning purposes, then deletes whatever it downloaded
+	# afterward (correct behavior for download-on-install packages, where that's meant to be
+	# scratch data). Because osfmount never set FileName32, that cleanup deleted this package's
+	# real, already-embedded osfmount.exe right after au_BeforeUpdate placed it -- AU still
+	# reported "updated ... and pushed" since nothing threw, but the pushed .nupkg had no exe
+	# (confirmed by downloading it directly from chocolatey.org). Setting FileName32 here tells
+	# Invoke-VirusTotalScan this file already exists and must be preserved, not scratch-cleaned.
+	$Latest.FileName32 = 'osfmount.exe'
 }
 
 function global:au_AfterUpdate($Package) {


### PR DESCRIPTION
## Why

#4330 (merged) added `-Force` to `Move-Item` and a post-move `Test-Path` check. AppVeyor build #8988 then re-pushed `osfmount v3.2.1001` — and it **still** failed moderation, with the exact same signature: [gist](https://gist.github.com/choco-bot/196f87dc71f6738d859baa6a738de271) shows `tools\chocolateyinstall.ps1` + a stray `osfmount.exe.ignore`, no `osfmount.exe`. Confirmed again by downloading the actual re-pushed `.nupkg` from chocolatey.org directly — no exe.

So #4330's fix was necessary (it does prevent a real, separate failure mode) but not sufficient. The build log for #8988 shows no error (`osfmount is updated to 3.2.1001.0 and pushed`), meaning the file *was* present when `au_BeforeUpdate` finished — something removed it afterward, before/during packaging.

## Real root cause

`scripts/Invoke-VirusTotalScan.ps1` (invoked from `au_AfterUpdate`) treats an unset `$Latest.FileName32` as "no file has been tracked for this package yet": it calls its own `Get-RemoteFiles` to fetch a copy into `tools\` purely for scanning, then deletes whatever it downloaded once the scan is done. That's the *correct* behavior for download-on-install packages — see `winflector-client`, which relies on exactly this mechanism (setting `FileName32` to avoid a separate `Get-RemoteFiles` redirect bug) and then explicitly deletes the file itself afterward in its own `au_AfterUpdate`, since it doesn't want the binary embedded.

`osfmount` never set `FileName32`. So the shared script treated its real, already-embedded `osfmount.exe` (placed by `au_BeforeUpdate`) as the same kind of scratch data — scanned it, then deleted it. `au_BeforeUpdate` had already succeeded and returned by that point, so nothing threw; AU just reported success on a package that no longer had its installer.

## Fix

Set `$Latest.FileName32 = 'osfmount.exe'` in `au_BeforeUpdate`. This marks the file as pre-existing to `Invoke-VirusTotalScan`, which then:
- skips the redundant `Get-RemoteFiles` re-download,
- scans the real `tools\osfmount.exe` directly (an improvement — previously it would've scanned a separately-fetched copy, not necessarily the one that got packaged),
- and skips the delete-after-scan step, since `$existingFileName32` is no longer empty.

nuspec reset to `0.0` again (bumped back to `3.2.1001.0` by the failed re-push) to force AU to re-push once this merges; `-NoCheckChocoVersion` from #4330 is already in place.

## Testing

- `pwsh -NoProfile` AST parse: no syntax errors.
- Isolated `pwsh` simulation of `Invoke-VirusTotalScan.ps1`'s exact branch logic with `$Latest.FileName32` set, against the real script's conditions — confirmed it skips both the `Get-RemoteFiles` call and the `Remove-Item` call.

---