### PR TITLE
docs(windjview): add note on antivirus false positives

### DIFF
--- a/automatic/windjview/README.md
+++ b/automatic/windjview/README.md
@@ -6,6 +6,9 @@ WinDjView is a fast, compact and powerful DjVu viewer for Windows with tabbed in
 [Forum](https://sourceforge.net/p/windjview/discussion/)
 [Source code](https://sourceforge.net/p/windjview/code/)
 
+### A note on antivirus detections
+Some antivirus engines have flagged the WinDjView installer with generic/heuristic detections (e.g. "Generic.Malware/Suspicious"). This is discussed in the thread ["Virus detected"](https://sourceforge.net/p/windjview/discussion/392867/thread/b60e69c48a/), on the project's own official SourceForge discussion forum (not a third-party site). Unlike NirSoft's tools, there's no developer statement confirming this as a false positive -- it's an old, unsigned, low-traffic binary, a common combination for heuristic antivirus engines to flag even when clean, but treat that as context rather than a guarantee. If your antivirus flags this package, please consider reporting it to your AV vendor as a false positive.
+
 ### Package-specific issue
 If this package isn't up-to-date for some days, [Create an issue](https://github.com/tunisiano187/Chocolatey-packages/issues/new/choose)
 

--- a/automatic/windjview/update.ps1
+++ b/automatic/windjview/update.ps1
@@ -55,4 +55,4 @@ function global:au_GetLatest {
 	}
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckChocoVersion

--- a/automatic/windjview/windjview.nuspec
+++ b/automatic/windjview/windjview.nuspec
@@ -18,7 +18,7 @@ WinDjView is a fast, compact and powerful DjVu viewer for Windows with tabbed in
 [Source code](https://sourceforge.net/p/windjview/code/)
 
 ### A note on antivirus detections
-Some antivirus engines have flagged the WinDjView installer with generic/heuristic detections (e.g. "Generic.Malware/Suspicious"). This has been discussed as a likely false positive by users on the project's own [SourceForge discussion forum](https://sourceforge.net/p/windjview/discussion/392867/thread/b60e69c48a/) and elsewhere -- the project is old, unsigned, and low-traffic, which is a common combination for heuristic antivirus engines to flag even when the binary is clean. If your antivirus flags this package, please consider reporting it to your AV vendor as a false positive.
+Some antivirus engines have flagged the WinDjView installer with generic/heuristic detections (e.g. "Generic.Malware/Suspicious"). This is discussed in the thread ["Virus detected"](https://sourceforge.net/p/windjview/discussion/392867/thread/b60e69c48a/), on the project's own official SourceForge discussion forum (not a third-party site). Unlike NirSoft's tools, there's no developer statement confirming this as a false positive -- it's an old, unsigned, low-traffic binary, a common combination for heuristic antivirus engines to flag even when clean, but treat that as context rather than a guarantee. If your antivirus flags this package, please consider reporting it to your AV vendor as a false positive.
 
 ### Package-specific issue
 If this package isn't up-to-date for some days, [Create an issue](https://github.com/tunisiano187/Chocolatey-packages/issues/new/choose)

--- a/automatic/windjview/windjview.nuspec
+++ b/automatic/windjview/windjview.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>windjview</id>
-    <version>2.1.20260729</version>
+    <version>0.0</version>
     <title>WinDjView</title>
     <authors>Andrew Zhezherun, Leonid Zhezherun</authors>
     <owners>tunisiano</owners>
@@ -16,6 +16,9 @@ WinDjView is a fast, compact and powerful DjVu viewer for Windows with tabbed in
 
 [Forum](https://sourceforge.net/p/windjview/discussion/)
 [Source code](https://sourceforge.net/p/windjview/code/)
+
+### A note on antivirus detections
+Some antivirus engines have flagged the WinDjView installer with generic/heuristic detections (e.g. "Generic.Malware/Suspicious"). This has been discussed as a likely false positive by users on the project's own [SourceForge discussion forum](https://sourceforge.net/p/windjview/discussion/392867/thread/b60e69c48a/) and elsewhere -- the project is old, unsigned, and low-traffic, which is a common combination for heuristic antivirus engines to flag even when the binary is clean. If your antivirus flags this package, please consider reporting it to your AV vendor as a false positive.
 
 ### Package-specific issue
 If this package isn't up-to-date for some days, [Create an issue](https://github.com/tunisiano187/Chocolatey-packages/issues/new/choose)


### PR DESCRIPTION
## Why

`windjview` (v2.1.20260729) has been stuck since 29 Jul in "Waiting for Maintainer" status. `chocolatey-ops` flagged it: *"Package virus scanning found that at least 1 file within, or downloaded by, the package has greater than 10 VirusTotal detections associated with it."*

Not a packaging bug — the installer itself is what's flagged. WinDjView's setup file has a documented history of generic/heuristic antivirus detections that users have discussed as likely false positives, e.g. on the project's own [SourceForge discussion thread](https://sourceforge.net/p/windjview/discussion/392867/thread/b60e69c48a/) and the [Malwarebytes forums](https://forums.malwarebytes.com/topic/322164-detection-in-windjview-setup-file-a-false-positive/). Consistent with it being an old, unsigned, low-traffic binary — a common combination for heuristic AV engines to flag even when clean. This is less definitively confirmed than `cports`' case (no official developer statement, just community discussion), so the note is worded accordingly.

## Change

Adds a short note to the package description for context. As with `cports` (#4334), this alone doesn't clear the moderation hold — that requires posting in the package's "Add to Review Comments" box directly on chocolatey.org as the logged-in maintainer.

nuspec reset to `0.0` + `-NoCheckChocoVersion` added to force AU to re-push with the updated description on the next run.

---